### PR TITLE
Fix duplicate YAML frontmatter keys in 9 template files

### DIFF
--- a/templates/Core/QUEST_TEMPLATE.md
+++ b/templates/Core/QUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "core"
 editable: false
 marketplace_eligible: false
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # Must match folder name (e.g., find_the_cure)
 entity_type: "quest"
 folder_name: "Quests"
 file_prefix: "QUEST_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # Must match folder name (e.g., find_the_cure)
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
 status: "active"  # active, disabled, completed, archived, draft

--- a/templates/Core/TIMELINE_TEMPLATE.md
+++ b/templates/Core/TIMELINE_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "core"
 editable: false
 marketplace_eligible: false
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # Must match timeline entry (e.g., campaign_start_main_story)
 entity_type: "timeline"
 folder_name: "Timelines"
 file_prefix: "TIMEL_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # Must match timeline entry (e.g., campaign_start_main_story)
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
 status: "active"  # active, draft, archived
@@ -86,7 +85,7 @@ vector_references:  # IDs of documents in vector database that support this entr
   - "doc_id_2"
 
 # TIMELINE ORGANIZATION
-id: "master_timeline"  # For nested/sub-timelines
+timeline_id: "master_timeline"  # For nested/sub-timelines
 sequence_order: 1  # Order within a sequence of related events
 prerequisites:  # Events that must happen before this one
   - "previous_event_id"

--- a/templates/ExampleImplementation/LOC_rustys_auto_repair.md
+++ b/templates/ExampleImplementation/LOC_rustys_auto_repair.md
@@ -1,7 +1,6 @@
 ---
 # LOCATION METADATA
 template_version: "1.0"
-location_type: "poi"
 created_date: "2025-01-15"
 last_updated: "2025-01-15"
 status: "active"

--- a/templates/Packs/starter-locations/templates/LOCATION_TEMPLATE.md
+++ b/templates/Packs/starter-locations/templates/LOCATION_TEMPLATE.md
@@ -162,7 +162,6 @@ infection_status: "contaminated"  # clean, contaminated, infected, quarantined
 # CONTENT FIELDS
 description: null  # Brief description (also in markdown below for details)
 atmosphere: null  # Atmosphere description (also in markdown below for details)
-notable_features: []  # List of key features
 hidden_secrets: []  # Hidden elements players can discover
 historical_context: null  # Will be in markdown below
 gameplay_notes: null  # Will be in markdown below

--- a/templates/Standard/CAMPAIGN_TEMPLATE.md
+++ b/templates/Standard/CAMPAIGN_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "entity"
 editable: true
 marketplace_eligible: true
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # Must match folder name (e.g., main_story)
 entity_type: "campaign"
 folder_name: "Campaigns"
 file_prefix: "CAMP_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # Must match folder name (e.g., main_story)
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
 associated_rules: []

--- a/templates/Standard/EVENT_TEMPLATE.md
+++ b/templates/Standard/EVENT_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "entity"
 editable: true
 marketplace_eligible: true
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # Must match folder name (e.g., zombie_horde_attack)
 entity_type: "event"
 folder_name: "Events"
 file_prefix: "EVENT_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # Must match folder name (e.g., zombie_horde_attack)
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
 associated_rules: []

--- a/templates/Standard/LOCATION_TEMPLATE.md
+++ b/templates/Standard/LOCATION_TEMPLATE.md
@@ -194,7 +194,6 @@ infection_status: "contaminated"  # clean, contaminated, infected, quarantined
 # CONTENT FIELDS
 description: null  # Brief description (also in markdown below for details)
 atmosphere: null  # Atmosphere description (also in markdown below for details)
-notable_features: []  # List of key features
 hidden_secrets: []  # Hidden elements players can discover
 historical_context: null  # Will be in markdown below
 gameplay_notes: null  # Will be in markdown below

--- a/templates/Standard/STYLE_BIBLE_TEMPLATE.md
+++ b/templates/Standard/STYLE_BIBLE_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "document"
 editable: true
 marketplace_eligible: true
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # Must match universe_id
 entity_type: "style_bible"
 folder_name: "Style Bibles"
 file_prefix: "STYLE_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # Must match universe_id
 universe_id: "universe_id"  # References universe configuration
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
@@ -169,7 +168,7 @@ special_font:
   usage: "Terminal displays, retro UI"
 
 # ANIMATION PRINCIPLES
-animation_style: "snappy_responsive"
+animation_approach: "snappy_responsive"
 frame_rate: 30  # fps
 key_principles:
   - "Anticipation before action"

--- a/templates/Standard/UNIVERSE_TEMPLATE.md
+++ b/templates/Standard/UNIVERSE_TEMPLATE.md
@@ -4,7 +4,7 @@ template_version: "1.0"
 template_category: "document"
 editable: true
 marketplace_eligible: true
-id: "[snake_case_name]"
+id: "[snake_case_name]"  # e.g., city_of_brains
 entity_type: "universe"
 folder_name: "Universes"
 file_prefix: "UNIV_"
@@ -12,7 +12,6 @@ asset_subfolders:
   - images
   - audio
   - video
-id: "unique_lowercase_id"  # e.g., city_of_brains
 created_date: "YYYY-MM-DD"
 last_updated: "YYYY-MM-DD"
 associated_rules:


### PR DESCRIPTION
## Summary
- Removes duplicate YAML frontmatter keys from 9 template files that cause silent data loss in Python (PyYAML overwrites) and parse failures in strict Rust YAML parsers
- Found 2 additional affected files beyond the 7 originally identified: `ExampleImplementation/LOC_rustys_auto_repair.md` (duplicate `location_type`) and `Packs/starter-locations/templates/LOCATION_TEMPLATE.md` (duplicate `notable_features`)

## Changes

| File | Duplicate Key | Resolution |
|------|--------------|------------|
| `Standard/CAMPAIGN_TEMPLATE.md` | `id` | Removed second, merged comment to first |
| `Standard/EVENT_TEMPLATE.md` | `id` | Removed second, merged comment to first |
| `Standard/LOCATION_TEMPLATE.md` | `notable_features` | Removed empty-list duplicate, kept populated list |
| `Standard/STYLE_BIBLE_TEMPLATE.md` | `id`, `animation_style` | Removed duplicate `id`; renamed second `animation_style` to `animation_approach` |
| `Standard/UNIVERSE_TEMPLATE.md` | `id` | Removed second, merged comment to first |
| `Core/QUEST_TEMPLATE.md` | `id` | Removed second, merged comment to first |
| `Core/TIMELINE_TEMPLATE.md` | `id` (x2) | Removed metadata duplicate; renamed timeline-org `id` to `timeline_id` |
| `Packs/starter-locations/templates/LOCATION_TEMPLATE.md` | `notable_features` | Removed empty-list duplicate |
| `ExampleImplementation/LOC_rustys_auto_repair.md` | `location_type` | Removed generic "poi", kept specific "auto_repair_shop" |

## Test Plan
- [x] Ran strict duplicate-key YAML checker across ALL template `.md` files -- zero duplicates found
- [x] Verified all 9 files parse with `yaml.safe_load()` after fix
- [ ] Backend template loading should parse these without silent key overwrites
- [ ] Rust parser (if used) should no longer reject these files

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>