### PR TITLE
SBAI-1841: Add editor_component viewer_component fields to layout JSON

### DIFF
--- a/templates/Layouts/assembly.layout.json
+++ b/templates/Layouts/assembly.layout.json
@@ -108,7 +108,9 @@
       },
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "assembly_composer_panel",
@@ -118,7 +120,9 @@
       "component_config": {},
       "component_source": "assembly-composer",
       "surface": "accent",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": "assembly-slot-editor",
+      "viewer_component": null
     },
     {
       "id": "assembly_inheritance_panel",
@@ -128,7 +132,9 @@
       "component_config": {},
       "component_source": "assembly-composer",
       "surface": "secondary",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": "inheritance-tree-viewer"
     },
     {
       "id": "production_status",
@@ -313,7 +319,9 @@
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "asset_browser",
@@ -321,7 +329,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "timeline_panel",
@@ -330,7 +340,9 @@
       "component": "entity-timeline",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-01T14:30:00.000000",

--- a/templates/Layouts/biome.layout.json
+++ b/templates/Layouts/biome.layout.json
@@ -103,7 +103,9 @@
       },
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "environment",
@@ -452,7 +454,9 @@
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -460,7 +464,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "view_config": {

--- a/templates/Layouts/brand.layout.json
+++ b/templates/Layouts/brand.layout.json
@@ -431,7 +431,9 @@
           "placeholder": "Brief brand positioning for AI marketing content",
           "column_span": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     }
   ]
 }

--- a/templates/Layouts/brand.layout.json
+++ b/templates/Layouts/brand.layout.json
@@ -84,7 +84,9 @@
           ],
           "column_span": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "temporal_information",
@@ -118,7 +120,9 @@
             {"key": "event", "label": "Milestone description"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "visual_identity",
@@ -147,7 +151,9 @@
             {"key": "body", "label": "Body Font"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "audio_identity",
@@ -176,7 +182,9 @@
           "placeholder": "e.g., cash register ding",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "brand_messaging",
@@ -212,7 +220,9 @@
           "placeholder": "casual and approachable",
           "column_span": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "corporate_structure",
@@ -256,7 +266,9 @@
           "placeholder": "150",
           "column_span": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "employment_personnel",
@@ -282,7 +294,9 @@
           "placeholder": "Select key personnel...",
           "column_span": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "market_presence",
@@ -333,7 +347,9 @@
           "placeholder": "e.g., retail stores, online delivery",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "public_perception",

--- a/templates/Layouts/campaign.layout.json
+++ b/templates/Layouts/campaign.layout.json
@@ -91,7 +91,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "story",
@@ -267,7 +269,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_timeline",
@@ -284,7 +288,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -292,11 +298,15 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/campaign.layout.json
+++ b/templates/Layouts/campaign.layout.json
@@ -81,7 +81,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -128,7 +130,9 @@
           "placeholder": "Add prerequisite..."
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "characters",
@@ -169,7 +173,9 @@
           "max_selections": 10,
           "placeholder": "Search for factions..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "locations",
@@ -202,7 +208,9 @@
           "max_selections": 20,
           "placeholder": "Search for secondary locations..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "quests",
@@ -229,7 +237,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add related event..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "rewards",
@@ -260,7 +270,9 @@
           "label": "Multiple Endings",
           "ui_component": "checkbox"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_relationships",

--- a/templates/Layouts/character.layout.json
+++ b/templates/Layouts/character.layout.json
@@ -146,7 +146,9 @@
       },
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_1771728956572",
@@ -156,7 +158,9 @@
       "component_config": {},
       "component_source": "hello-world",
       "surface": "accent",
-      "description": "Notes"
+      "description": "Notes",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_1771788397362",
@@ -165,7 +169,9 @@
       "component": "entity-timeline",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "temporal_information",
@@ -720,7 +726,9 @@
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_1771728678701",
@@ -728,7 +736,9 @@
       "icon": "bar-chart",
       "component": "plugin:hello-world:entity-stats",
       "component_config": {},
-      "component_source": "hello-world"
+      "component_source": "hello-world",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_1771782682484",
@@ -736,7 +746,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_1771792480053",
@@ -744,7 +756,9 @@
       "icon": "clock",
       "component": "plugin:time-tracker:time-log",
       "component_config": {},
-      "component_source": "time-tracker"
+      "component_source": "time-tracker",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-02-22T20:35:21.460444",

--- a/templates/Layouts/character.layout.json
+++ b/templates/Layouts/character.layout.json
@@ -663,7 +663,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add special ability..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "story_integration",
@@ -690,7 +692,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add service..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "ai_context",

--- a/templates/Layouts/dialogue.layout.json
+++ b/templates/Layouts/dialogue.layout.json
@@ -56,7 +56,9 @@
           "label": "Primary Image",
           "ui_component": "text"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -94,7 +96,9 @@
           "placeholder": "Search for participating characters..."
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "context",
@@ -135,7 +139,9 @@
           "max_selections": 1,
           "placeholder": "Search for location..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "tree_configuration",
@@ -183,7 +189,9 @@
           "ui_component": "number",
           "placeholder": "1"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "lines_and_choices",

--- a/templates/Layouts/dialogue.layout.json
+++ b/templates/Layouts/dialogue.layout.json
@@ -66,7 +66,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "speakers",
@@ -206,7 +208,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_timeline",
@@ -215,7 +219,9 @@
       "component": "entity-timeline",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "markdown_body",
@@ -223,7 +229,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -231,11 +239,15 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/district.layout.json
+++ b/templates/Layouts/district.layout.json
@@ -789,7 +789,9 @@
           "rows": 2,
           "placeholder": "Brief cultural and social context for AI content creation"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     }
   ]
 }

--- a/templates/Layouts/district.layout.json
+++ b/templates/Layouts/district.layout.json
@@ -91,7 +91,9 @@
           "rows": 3,
           "placeholder": "Brief description of the district's character and purpose"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "geographic_information",
@@ -145,7 +147,9 @@
             }
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "governance_control",
@@ -242,7 +246,9 @@
             { "value": "rampant", "label": "Rampant" }
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "economic_profile",
@@ -305,7 +311,9 @@
           "placeholder": "Search for businesses and brands...",
           "max_selections": 20
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "infrastructure_services",
@@ -482,7 +490,9 @@
           "column_span": 2,
           "placeholder": "e.g., Historic clock tower, Underground tunnels"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "demographics_current_status",
@@ -609,7 +619,9 @@
           "column_span": 1,
           "placeholder": "12000"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "environment_atmosphere",
@@ -671,7 +683,9 @@
           "description": "Notable landmarks and recognizable features of the district.",
           "placeholder": "e.g., city hall, central park, clock tower"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "security_safety",
@@ -728,7 +742,9 @@
           "description": "Areas to avoid or approach with extreme caution.",
           "placeholder": "e.g., abandoned subway, old hospital"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "story_integration",

--- a/templates/Layouts/event.layout.json
+++ b/templates/Layouts/event.layout.json
@@ -86,7 +86,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "timing",
@@ -260,7 +262,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_timeline",
@@ -269,7 +273,9 @@
       "component": "entity-timeline",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "markdown_body",
@@ -277,7 +283,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -285,11 +293,15 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/event.layout.json
+++ b/templates/Layouts/event.layout.json
@@ -76,7 +76,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -149,7 +151,9 @@
           ]
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "involved_entities",
@@ -198,7 +202,9 @@
           "max_selections": 20,
           "placeholder": "Search for related quests..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "phases_and_outcome",
@@ -253,7 +259,9 @@
           "rows": 2,
           "placeholder": "WARNING: Massive zombie horde detected..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_relationships",

--- a/templates/Layouts/faction.layout.json
+++ b/templates/Layouts/faction.layout.json
@@ -434,7 +434,9 @@
           "rows": 2,
           "placeholder": "How faction members typically behave and interact for AI generation"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     }
   ]
 }

--- a/templates/Layouts/faction.layout.json
+++ b/templates/Layouts/faction.layout.json
@@ -94,7 +94,9 @@
           "column_span": 2,
           "placeholder": "Faction motto or rallying cry"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "leadership",
@@ -140,7 +142,9 @@
           "placeholder": "Search for key faction members...",
           "max_selections": 20
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "territory_operations",
@@ -185,7 +189,9 @@
           "placeholder": "Search for controlled territories...",
           "max_selections": 25
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "faction_relationships",
@@ -231,7 +237,9 @@
           "placeholder": "Search for enemy factions...",
           "max_selections": 15
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "resources_assets",
@@ -285,7 +293,9 @@
             { "value": "cutting_edge", "label": "Cutting Edge" }
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "ideology_beliefs",
@@ -333,7 +343,9 @@
           "rows": 3,
           "placeholder": "Enter forbidden practices (one per line)"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "military_capabilities",

--- a/templates/Layouts/item.layout.json
+++ b/templates/Layouts/item.layout.json
@@ -96,7 +96,9 @@
           "column_span": 2,
           "placeholder": "Short catchy description"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "brand_association",
@@ -120,7 +122,9 @@
           ],
           "placeholder": "Search for associated brand..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "availability",
@@ -160,7 +164,9 @@
           "help": "Characters who sell this item.",
           "placeholder": "Search for vendor characters..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "game_mechanics",
@@ -192,7 +198,9 @@
           "ui_component": "number",
           "placeholder": "0"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "flags",

--- a/templates/Layouts/item.layout.json
+++ b/templates/Layouts/item.layout.json
@@ -222,7 +222,9 @@
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ]
 }

--- a/templates/Layouts/job.layout.json
+++ b/templates/Layouts/job.layout.json
@@ -211,7 +211,8 @@
           "help": "Peer positions this job works closely with.",
           "placeholder": "Add collaborative positions..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     }
-  ]
-}
+  ],

--- a/templates/Layouts/job.layout.json
+++ b/templates/Layouts/job.layout.json
@@ -87,7 +87,9 @@
           "rows": 4,
           "placeholder": "Detailed description of the job role and responsibilities..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "visual_design",
@@ -107,7 +109,9 @@
           "placeholder": "images/jobs/job_logo.png",
           "help": "Path to the primary image/logo for this job position"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "brand_organization",
@@ -131,7 +135,9 @@
           "help": "Other brands that may offer similar positions.",
           "placeholder": "Add associated brands..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "work_locations",
@@ -147,7 +153,9 @@
           "reference_type": "location",
           "placeholder": "Add work locations..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "career_progression",

--- a/templates/Layouts/location.layout.json
+++ b/templates/Layouts/location.layout.json
@@ -78,7 +78,9 @@
             {"value": "minor", "label": "Minor"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "temporal_information",
@@ -111,7 +113,9 @@
             {"key": "event", "label": "Event", "ui_component": "text", "placeholder": "Event description"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "geographic_information",
@@ -154,7 +158,9 @@
           "rows": 2,
           "placeholder": "Describe the mood and feeling of this location..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "population_control",
@@ -261,7 +267,9 @@
           "placeholder": "Search for controlling faction...",
           "max_selections": 1
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "business_commerce",
@@ -306,7 +314,9 @@
           "placeholder": "Search for job positions...",
           "max_selections": 10
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "economy_services",
@@ -367,7 +377,9 @@
           "help": "Services, functions, or activities available at this location.",
           "placeholder": "e.g., buy items, repair equipment, medical aid"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "available_items",
@@ -419,7 +431,9 @@
           "help": "Key distinguishing characteristics that make this location memorable.",
           "placeholder": "Notable feature"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "hidden_secrets",
@@ -513,7 +527,9 @@
           "ui_component": "checkbox",
           "group": "accessibility"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "environment_atmosphere",
@@ -570,7 +586,9 @@
           "label": "Accent Color",
           "ui_component": "color"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "security_safety",
@@ -602,7 +620,9 @@
             {"value": "critical", "label": "Critical"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "story_integration",
@@ -633,7 +653,9 @@
             {"value": "neutral", "label": "Neutral"}
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "safety_hazards",
@@ -709,7 +731,9 @@
             }
           ]
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "ai_context",

--- a/templates/Layouts/location.layout.json
+++ b/templates/Layouts/location.layout.json
@@ -748,7 +748,9 @@
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ]
 }

--- a/templates/Layouts/quest.layout.json
+++ b/templates/Layouts/quest.layout.json
@@ -92,7 +92,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "organization",
@@ -284,7 +286,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_timeline",
@@ -293,7 +297,9 @@
       "component": "entity-timeline",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "markdown_body",
@@ -301,7 +307,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -309,11 +317,15 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "comfyui",
-      "component": "entity-workflow-trigger"
+      "component": "entity-workflow-trigger",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/quest.layout.json
+++ b/templates/Layouts/quest.layout.json
@@ -82,7 +82,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -124,7 +126,9 @@
           "placeholder": "Add required skill..."
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "objectives",
@@ -165,7 +169,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add failure condition..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "characters_involved",
@@ -206,7 +212,9 @@
           "max_selections": 10,
           "placeholder": "Search for factions..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "locations",
@@ -239,7 +247,9 @@
           "max_selections": 1,
           "placeholder": "Search for destination..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "rewards",

--- a/templates/Layouts/style_bible.layout.json
+++ b/templates/Layouts/style_bible.layout.json
@@ -74,7 +74,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "visual_identity",
@@ -282,7 +284,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "markdown_body",
@@ -290,7 +294,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -298,7 +304,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/style_bible.layout.json
+++ b/templates/Layouts/style_bible.layout.json
@@ -64,7 +64,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -121,7 +123,9 @@
           "placeholder": "Add influence..."
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "color_palette",
@@ -156,7 +160,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add forbidden color..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "lighting",
@@ -211,7 +217,9 @@
           "label": "Ambient Occlusion",
           "ui_component": "checkbox"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "typography",
@@ -275,7 +283,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add environmental detail..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_relationships",

--- a/templates/Layouts/timeline.layout.json
+++ b/templates/Layouts/timeline.layout.json
@@ -67,7 +67,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -119,7 +121,9 @@
           "placeholder": "0"
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "context_references",
@@ -160,7 +164,9 @@
           "max_selections": 1,
           "placeholder": "Search for dialogue..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "entities_involved",
@@ -201,7 +207,9 @@
           "max_selections": 10,
           "placeholder": "Search for brands..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "consequences",
@@ -232,7 +240,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add enabled entry..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "sources",

--- a/templates/Layouts/timeline.layout.json
+++ b/templates/Layouts/timeline.layout.json
@@ -77,7 +77,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "timing",
@@ -260,7 +262,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_timeline",
@@ -277,7 +281,9 @@
       "icon": "FileText",
       "component": "markdown-content",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_assets",
@@ -285,7 +291,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",

--- a/templates/Layouts/universe.layout.json
+++ b/templates/Layouts/universe.layout.json
@@ -91,7 +91,9 @@
       "component_config": {"object_fit": "contain"},
       "component_source": "builtin",
       "surface": "base",
-      "collapsed_default": false
+      "collapsed_default": false,
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "setting",
@@ -279,7 +281,9 @@
       "component": "entity-relationships",
       "component_config": {},
       "component_source": "builtin",
-      "surface": "accent"
+      "surface": "accent",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "markdown_body",

--- a/templates/Layouts/universe.layout.json
+++ b/templates/Layouts/universe.layout.json
@@ -81,7 +81,9 @@
           "ui_component": "text",
           "column_span": 2
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "block_primary_image",
@@ -145,7 +147,9 @@
           "placeholder": "Add a technology rule..."
         }
       ],
-      "surface": "secondary"
+      "surface": "secondary",
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "themes_and_tone",
@@ -172,7 +176,9 @@
           "ui_component": "text",
           "placeholder": "dark_comedy_horror"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "visual_style",
@@ -211,7 +217,9 @@
           "ui_component": "tag-input",
           "placeholder": "Add atmospheric element..."
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "audio_direction",
@@ -239,7 +247,9 @@
           "column_span": 2,
           "placeholder": "naturalistic_90s"
         }
-      ]
+      ],
+      "editor_component": null,
+      "viewer_component": null
     },
     {
       "id": "narrative_rules",
@@ -299,7 +309,9 @@
       "icon": "Image",
       "component": "entity-assets",
       "component_config": {},
-      "component_source": "builtin"
+      "component_source": "builtin",
+      "editor_component": null,
+      "viewer_component": null
     }
   ],
   "updated_at": "2026-04-06T00:00:00.000Z",


### PR DESCRIPTION
Resolves SBAI-1841.

This PR adds optional editor_component and viewer_component fields to all 16 template layout JSON files. These fields allow templates to specify custom React components when the default UI built-ins are insufficient for bespoke editing or viewing requirements.

Files changed:
- assembly.layout.json
- biome.layout.json
- brand.layout.json
- campaign.layout.json
- character.layout.json
- dialogue.layout.json
- district.layout.json
- event.layout.json
- faction.layout.json
- item.layout.json
- job.layout.json
- location.layout.json
- quest.layout.json
- style_bible.layout.json
- timeline.layout.json
- universe.layout.json