### PR TITLE
SBAI-3059: Remove unused Python imports across plugin backends

### DIFF
--- a/plugins/assembly-composer/backend/routes.py
+++ b/plugins/assembly-composer/backend/routes.py
@@ -10,7 +10,7 @@ import os
 import re
 import logging
 import yaml
-from typing import Any, Optional
+from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 

--- a/plugins/blender-bridge/backend/routes.py
+++ b/plugins/blender-bridge/backend/routes.py
@@ -13,7 +13,7 @@ import re
 import time
 import uuid
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import aiohttp
 from fastapi import APIRouter, HTTPException

--- a/plugins/comfyui-workflows/backend/routes.py
+++ b/plugins/comfyui-workflows/backend/routes.py
@@ -7,8 +7,6 @@ tracking execution history, and serving generated outputs.
 
 import json
 import logging
-import os
-import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path

--- a/plugins/comparison/backend/routes.py
+++ b/plugins/comparison/backend/routes.py
@@ -14,7 +14,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from difflib import unified_diff
 
 from fastapi import APIRouter, HTTPException

--- a/plugins/discord-poster/backend/routes.py
+++ b/plugins/discord-poster/backend/routes.py
@@ -7,7 +7,6 @@ managing webhook configurations, and tracking post history.
 
 import json
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path

--- a/plugins/entity-validator/backend/routes.py
+++ b/plugins/entity-validator/backend/routes.py
@@ -136,7 +136,7 @@ def _validate_frontmatter(
         ``value``   — the offending value (omitted for missing required fields)
     """
     try:
-        import jsonschema
+        import jsonschema  # noqa: F401 — availability probe
         from jsonschema import Draft202012Validator, RefResolver
     except ImportError:
         logger.warning(

--- a/plugins/hello-world/backend/routes.py
+++ b/plugins/hello-world/backend/routes.py
@@ -10,7 +10,6 @@ import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel

--- a/plugins/import-export-pipeline/backend/routes.py
+++ b/plugins/import-export-pipeline/backend/routes.py
@@ -12,14 +12,13 @@ Features:
 - AI-assisted merge conflict resolution
 """
 
-import asyncio
 import logging
 import os
 import re
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 from enum import Enum
 
@@ -800,7 +799,6 @@ async def export_csv(
     Flattens entity data for spreadsheet compatibility.
     """
     import csv
-    import io
 
     task_id = f"export-csv-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
 
@@ -939,7 +937,6 @@ async def export_pdf(
 
     Uses Playwright for high-quality PDF generation.
     """
-    import asyncio
 
     task_id = f"export-pdf-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
 
@@ -1046,7 +1043,7 @@ async def export_docx(
     Generates professional Word documents with styles.
     """
     from docx import Document
-    from docx.shared import Pt, Inches
+    from docx.shared import Pt
     from docx.enum.text import WD_ALIGN_PARAGRAPH
 
     task_id = f"export-docx-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"

--- a/plugins/jira-sync/backend/events.py
+++ b/plugins/jira-sync/backend/events.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 

--- a/plugins/jira-sync/backend/routes.py
+++ b/plugins/jira-sync/backend/routes.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Body, Query
+from fastapi import APIRouter, HTTPException, Body
 
 router = APIRouter()
 logger = logging.getLogger("plugin.jira-sync")

--- a/plugins/lora-trainer/backend/routes.py
+++ b/plugins/lora-trainer/backend/routes.py
@@ -8,7 +8,6 @@ linked to character entities.
 
 import json
 import logging
-import os
 import re
 import time
 import uuid

--- a/plugins/music-gen/backend/routes.py
+++ b/plugins/music-gen/backend/routes.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.music-gen")
 

--- a/plugins/obsidian-vault/backend/routes.py
+++ b/plugins/obsidian-vault/backend/routes.py
@@ -11,14 +11,11 @@ import logging
 import os
 import re
 import shutil
-import time
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.obsidian-vault")

--- a/plugins/pdf-exporter/backend/routes.py
+++ b/plugins/pdf-exporter/backend/routes.py
@@ -13,14 +13,11 @@ Routes (mounted at /api/ext/pdf-exporter/...):
   POST /batch                             — batch export multiple entities
 """
 
-import json
 import logging
-import os
 import re
-import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query

--- a/plugins/prompt-engine/backend/routes.py
+++ b/plugins/prompt-engine/backend/routes.py
@@ -27,7 +27,7 @@ import re
 import time
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger("plugin.prompt-engine")

--- a/plugins/showrunner-exporter/backend/routes.py
+++ b/plugins/showrunner-exporter/backend/routes.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.showrunner-exporter")

--- a/plugins/social-publisher/backend/events.py
+++ b/plugins/social-publisher/backend/events.py
@@ -54,7 +54,6 @@ async def _auto_post(entity_type: str, entity_id: str, settings: dict):
             _render_template,
             _load_templates,
             _append_history,
-            _platform_configured,
             PUBLISHER_MAP,
             PLATFORMS,
         )

--- a/plugins/social-publisher/backend/routes.py
+++ b/plugins/social-publisher/backend/routes.py
@@ -12,14 +12,13 @@ render previews.
 
 import json
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.social-publisher")

--- a/plugins/uefn-exporter/backend/routes.py
+++ b/plugins/uefn-exporter/backend/routes.py
@@ -7,7 +7,6 @@ and Creative island metadata from City of Brains Studio entities.
 All routes are mounted at /api/ext/uefn-exporter/ by the plugin loader.
 """
 
-import json
 import logging
 import os
 import re

--- a/plugins/unity-exporter/backend/routes.py
+++ b/plugins/unity-exporter/backend/routes.py
@@ -13,7 +13,6 @@ import json
 import logging
 import re
 import shutil
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/plugins/voice-forge/backend/routes.py
+++ b/plugins/voice-forge/backend/routes.py
@@ -7,7 +7,6 @@ and audio history tracking for character entities.
 
 import json
 import logging
-import os
 import time
 import uuid
 from pathlib import Path

--- a/plugins/webhook-automations/backend/routes.py
+++ b/plugins/webhook-automations/backend/routes.py
@@ -16,7 +16,6 @@ from datetime import datetime, timezone
 import httpx
 import hmac
 import hashlib
-import asyncio
 
 from services.plugin_data_service import PluginDataService
 

--- a/plugins/youtube-manager/backend/routes.py
+++ b/plugins/youtube-manager/backend/routes.py
@@ -3,16 +3,13 @@ YouTube Manager Plugin - Backend Routes
 Handles video uploads, metadata management, and YouTube API integration.
 """
 
-from fastapi import APIRouter, HTTPException, UploadFile, File, Form
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Optional, List
 from pathlib import Path
 from datetime import datetime
 import json
 import uuid
-import os
-import shutil
 
 router = APIRouter()
 


### PR DESCRIPTION
Resolves SBAI-3059

## Summary
- Ran `ruff check . --select=F401 --fix` to auto-remove 40 unused imports across 23 plugin backend Python files
- Added `# noqa: F401` comment for intentional `jsonschema` availability probe in entity-validator

## Files Changed
23 files in `plugins/*/backend/` — all are removal of unused F401 imports only:
- assembly-composer, blender-bridge, comfyui-workflows, comparison, discord-poster, entity-validator, hello-world, import-export-pipeline, jira-sync (events + routes), lora-trainer, music-gen, obsidian-vault, pdf-exporter, prompt-engine, showrunner-exporter, social-publisher (events + routes), uefn-exporter, unity-exporter, voice-forge, webhook-automations, youtube-manager

## Testing
- `ruff check . --select=F401` passes with zero errors after changes
- Pre-existing non-F401 issues (F841, E402) are unchanged