### PR TITLE
SBAI-3077: Remove unused Python imports across plugin backend files

### DIFF
--- a/plugins/assembly-composer/backend/routes.py
+++ b/plugins/assembly-composer/backend/routes.py
@@ -10,7 +10,7 @@ import os
 import re
 import logging
 import yaml
-from typing import Any, Optional
+from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
@@ -27,7 +27,6 @@ EXPORT_PROFILES_DIR = os.path.join(
     DATA_ROOT, "templates", "Standard", "ExportProfiles"
 )
 
-
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
@@ -40,17 +39,14 @@ class SlotAssignRequest(BaseModel):
     variant_key: Optional[str] = None
     z_index_override: Optional[int] = None
 
-
 class SlotLockRequest(BaseModel):
     assembly_id: str
     slot_path: str          # "slot_group.slot_name"
     locked: bool
 
-
 class ZIndexReorderRequest(BaseModel):
     assembly_id: str
     reorder: list[dict]     # [{"slot_group": str, "slot_name": str, "z_index": int}]
-
 
 class ExportRequest(BaseModel):
     assembly_id: str
@@ -58,14 +54,12 @@ class ExportRequest(BaseModel):
     color_variant: Optional[str] = "default"
     zombie_stage: Optional[int] = 0
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 # Allow only safe identifier characters to prevent path traversal
 _SAFE_ID_RE = re.compile(r'^[A-Za-z0-9_\-]+$')
-
 
 def _validate_id(value: str, label: str) -> None:
     """Reject any ID that contains path-traversal characters."""
@@ -75,7 +69,6 @@ def _validate_id(value: str, label: str) -> None:
             detail=f"{label} contains invalid characters. "
                    "Only letters, digits, underscores, and hyphens are allowed.",
         )
-
 
 def _load_assembly_frontmatter(assembly_id: str) -> dict:
     """Load and parse the YAML frontmatter of an assembly markdown file."""
@@ -103,7 +96,6 @@ def _load_assembly_frontmatter(assembly_id: str) -> dict:
     except yaml.YAMLError as exc:
         raise HTTPException(status_code=422, detail=f"YAML parse error: {exc}")
 
-
 def _resolve_inheritance_chain(assembly_id: str, depth: int = 0) -> list[dict]:
     """Walk up the parent chain and return ordered list of frontmatter dicts (root first)."""
     if depth > 4:
@@ -116,7 +108,6 @@ def _resolve_inheritance_chain(assembly_id: str, depth: int = 0) -> list[dict]:
     chain.append(data)
     return chain
 
-
 def _collect_locked_slots(chain: list[dict]) -> set[str]:
     """Aggregate all locked_slots across the inheritance chain."""
     locked: set[str] = set()
@@ -125,14 +116,12 @@ def _collect_locked_slots(chain: list[dict]) -> set[str]:
             locked.add(path)
     return locked
 
-
 def _validate_z_index(z_index: int) -> None:
     if not (1 <= z_index <= 999):
         raise HTTPException(
             status_code=422,
             detail=f"z_index {z_index} out of range 1–999"
         )
-
 
 # ---------------------------------------------------------------------------
 # Routes — Assembly metadata
@@ -171,12 +160,10 @@ def list_assemblies(
         })
     return {"assemblies": results}
 
-
 @router.get("/api/plugins/assembly-composer/assemblies/{assembly_id}")
 def get_assembly(assembly_id: str):
     """Return the full frontmatter for a single assembly."""
     return _load_assembly_frontmatter(assembly_id)
-
 
 @router.get("/api/plugins/assembly-composer/assemblies/{assembly_id}/inheritance")
 def get_inheritance_chain(assembly_id: str):
@@ -197,7 +184,6 @@ def get_inheritance_chain(assembly_id: str):
         ],
         "all_locked_slots": sorted(locked),
     }
-
 
 # ---------------------------------------------------------------------------
 # Routes — Slot management
@@ -233,7 +219,6 @@ def get_slot_map(assembly_id: str):
         "slot_definitions": slot_map,
         "locked_slots": sorted(locked),
     }
-
 
 @router.post("/api/plugins/assembly-composer/assemblies/{assembly_id}/slots/assign")
 def assign_slot(assembly_id: str, req: SlotAssignRequest):
@@ -276,7 +261,6 @@ def assign_slot(assembly_id: str, req: SlotAssignRequest):
         "message": "Slot assignment validated. Apply via entity write API.",
     }
 
-
 @router.post("/api/plugins/assembly-composer/assemblies/{assembly_id}/slots/lock")
 def set_slot_lock(assembly_id: str, req: SlotLockRequest):
     """
@@ -307,7 +291,6 @@ def set_slot_lock(assembly_id: str, req: SlotLockRequest):
         "message": "Lock change validated. Apply via entity write API.",
     }
 
-
 @router.post("/api/plugins/assembly-composer/assemblies/{assembly_id}/slots/reorder")
 def reorder_z_indices(assembly_id: str, req: ZIndexReorderRequest):
     """
@@ -335,7 +318,6 @@ def reorder_z_indices(assembly_id: str, req: ZIndexReorderRequest):
         "message": "Z-index reorder validated. Apply via entity write API.",
     }
 
-
 # ---------------------------------------------------------------------------
 # Routes — Export
 # ---------------------------------------------------------------------------
@@ -351,7 +333,6 @@ def list_export_profiles():
             profile_id = fname[:-5]
             profiles.append({"id": profile_id, "file": fname})
     return {"profiles": profiles}
-
 
 @router.post("/api/plugins/assembly-composer/export")
 def request_export(req: ExportRequest):
@@ -403,7 +384,6 @@ def request_export(req: ExportRequest):
             "Export job queued. Required slot fill status must be confirmed by the export service."
         ),
     }
-
 
 @router.get("/api/plugins/assembly-composer/assemblies/{assembly_id}/preview")
 def get_preview_info(assembly_id: str):

--- a/plugins/blender-bridge/backend/routes.py
+++ b/plugins/blender-bridge/backend/routes.py
@@ -13,7 +13,7 @@ import re
 import time
 import uuid
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import aiohttp
 from fastapi import APIRouter, HTTPException
@@ -49,7 +49,6 @@ TYPE_PREFIX_MAP = {
     "job": "JOB",
 }
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -58,26 +57,22 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("blender-bridge").get(key, default)
 
-
 def _blender_url() -> str:
     """Build the Blender command server URL from settings."""
     host = _get_setting("blender_host", "localhost")
     port = _get_setting("blender_port", 8400)
     return f"http://{host}:{port}"
 
-
 def _get_type_dir(entity_type: str) -> str:
     """Return the directory name for a given entity type (e.g. character -> Characters)."""
     singular = entity_type.rstrip("s")
     return singular.capitalize() + "s"
-
 
 def _get_entity_file(entity_type: str, entity_id: str) -> str:
     """Return absolute path to an entity's markdown file."""
     type_dir = _get_type_dir(entity_type)
     prefix = TYPE_PREFIX_MAP.get(entity_type, entity_type.upper())
     return str(BRAINS_ROOT / type_dir / entity_id / f"{prefix}_{entity_id}.md")
-
 
 def _parse_frontmatter(filepath: str) -> dict:
     """Read a markdown file and extract YAML frontmatter as a dict."""
@@ -103,7 +98,6 @@ def _parse_frontmatter(filepath: str) -> dict:
                 data[key.strip()] = val
         return data
 
-
 def _load_json(path: Path, default=None):
     """Load JSON from a file, returning default on any error."""
     if default is None:
@@ -115,29 +109,23 @@ def _load_json(path: Path, default=None):
         pass
     return default
 
-
 def _save_json(path: Path, data, max_entries: int = 0):
     """Save data as JSON. If max_entries > 0 and data is a list, truncate."""
     if max_entries > 0 and isinstance(data, list):
         data = data[-max_entries:]
     path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
 
-
 def _load_export_log() -> list:
     return _load_json(EXPORT_LOG_FILE, [])
-
 
 def _save_export_log(log: list):
     _save_json(EXPORT_LOG_FILE, log, max_entries=500)
 
-
 def _load_render_queue() -> list:
     return _load_json(RENDER_QUEUE_FILE, [])
 
-
 def _save_render_queue(queue: list):
     _save_json(RENDER_QUEUE_FILE, queue, max_entries=200)
-
 
 # ---------------------------------------------------------------------------
 # Entity -> Blender data conversion
@@ -152,7 +140,6 @@ def _ensure_list(val) -> list:
     if isinstance(val, str):
         return [val] if val.strip() else []
     return [val]
-
 
 def entity_to_blender_data(entity_type: str, entity_id: str, entity_data: dict) -> dict:
     """
@@ -267,7 +254,6 @@ def entity_to_blender_data(entity_type: str, entity_id: str, entity_data: dict) 
 
     return base
 
-
 def _parse_character_dimensions(data: dict) -> dict:
     """
     Parse height string (e.g. '6\\'2"', '5 foot 10', '180cm') into
@@ -312,14 +298,12 @@ def _parse_character_dimensions(data: dict) -> dict:
         "armature_scale": [width_factor, width_factor, meters / 1.75],
     }
 
-
 def _to_float(val, default: float = 0.0) -> float:
     """Safely convert to float."""
     try:
         return float(val)
     except (TypeError, ValueError):
         return default
-
 
 def _build_scene_setup(data: dict) -> dict:
     """Build Blender scene setup hints from location data."""
@@ -349,12 +333,10 @@ def _build_scene_setup(data: dict) -> dict:
         "has_exterior": data.get("exterior_access", False),
     }
 
-
 def _entity_images_dir(entity_type: str, entity_id: str) -> Path:
     """Return the images directory for an entity."""
     type_folder = _get_type_dir(entity_type)
     return BRAINS_ROOT / type_folder / entity_id / "images"
-
 
 # ---------------------------------------------------------------------------
 # Request models
@@ -363,7 +345,6 @@ def _entity_images_dir(entity_type: str, entity_id: str) -> Path:
 class BatchExportRequest(BaseModel):
     entity_type: str
     entity_ids: List[str]
-
 
 class RenderRequest(BaseModel):
     scene_file: str
@@ -375,7 +356,6 @@ class RenderRequest(BaseModel):
         "resolution_y": 1080,
         "output_format": "PNG",
     })
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -414,7 +394,6 @@ async def plugin_status():
         "completed_renders": len([r for r in render_queue if r.get("status") == "completed"]),
     }
 
-
 @router.get("/connection-status")
 async def connection_status():
     """Detailed Blender connection check."""
@@ -447,7 +426,6 @@ async def connection_status():
 
     return result
 
-
 @router.get("/export-format/{entity_type}/{entity_id}")
 async def preview_export(entity_type: str, entity_id: str):
     """Preview the Blender export data for an entity without actually exporting."""
@@ -464,7 +442,6 @@ async def preview_export(entity_type: str, entity_id: str):
         "preview": True,
         "blender_data": blender_data,
     }
-
 
 @router.post("/export/{entity_type}/{entity_id}")
 async def export_entity(entity_type: str, entity_id: str):
@@ -530,7 +507,6 @@ async def export_entity(entity_type: str, entity_id: str):
         "blender_error": blender_error,
         "blender_data": blender_data,
     }
-
 
 @router.post("/batch-export")
 async def batch_export(req: BatchExportRequest):
@@ -607,7 +583,6 @@ async def batch_export(req: BatchExportRequest):
         "blender_error": blender_error,
     }
 
-
 @router.post("/render-request")
 async def create_render_request(req: RenderRequest):
     """Queue a render request for Blender."""
@@ -662,7 +637,6 @@ async def create_render_request(req: RenderRequest):
         "error": render_entry["error"],
     }
 
-
 @router.get("/renders")
 async def list_renders():
     """List all render requests and their statuses."""
@@ -692,14 +666,12 @@ async def list_renders():
         "completed": len([r for r in queue if r.get("status") == "completed"]),
     }
 
-
 @router.get("/export-log")
 async def get_export_log():
     """Return recent export history."""
     log = _load_export_log()
     log.reverse()
     return {"entries": log[:100]}
-
 
 @router.get("/exports/{entity_type}/{entity_id}")
 async def get_entity_exports(entity_type: str, entity_id: str):
@@ -722,7 +694,6 @@ async def get_entity_exports(entity_type: str, entity_id: str):
         "entity_id": entity_id,
         "exports": exports,
     }
-
 
 @router.get("/available-entities/{entity_type}")
 async def list_available_entities(entity_type: str):

--- a/plugins/comfyui-workflows/backend/routes.py
+++ b/plugins/comfyui-workflows/backend/routes.py
@@ -7,8 +7,7 @@ tracking execution history, and serving generated outputs.
 
 import json
 import logging
-import os
-import re
+
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,11 +36,9 @@ BACKEND_URL = "http://localhost:8201"
 DEFAULT_COMFYUI_URL = "http://localhost:8188"
 DEFAULT_WORKFLOWS_DIR = r"A:\Brains\Workflows"
 
-
 def _ensure_dirs():
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
-
 
 # ---------------------------------------------------------------------------
 # Settings helpers
@@ -50,15 +47,12 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("comfyui-workflows").get(key, default)
 
-
 def _comfyui_url() -> str:
     return _get_setting("comfyui_url", DEFAULT_COMFYUI_URL).rstrip("/")
-
 
 def _workflows_dir() -> Path:
     d = _get_setting("workflows_dir", DEFAULT_WORKFLOWS_DIR)
     return Path(d) if d else Path(DEFAULT_WORKFLOWS_DIR)
-
 
 # ---------------------------------------------------------------------------
 # ComfyUI workflow parser
@@ -187,7 +181,6 @@ def _parse_workflow(filepath: Path) -> dict:
         "created": datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc).isoformat(),
     }
 
-
 # ---------------------------------------------------------------------------
 # ComfyUI communication helpers
 # ---------------------------------------------------------------------------
@@ -205,7 +198,6 @@ async def _comfyui_get(path: str) -> dict:
     except Exception as e:
         return {"error": str(e)}
 
-
 async def _comfyui_post(path: str, data: dict) -> dict:
     """POST request to ComfyUI server."""
     url = f"{_comfyui_url()}{path}"
@@ -220,7 +212,6 @@ async def _comfyui_post(path: str, data: dict) -> dict:
         return {"error": f"Cannot connect to ComfyUI: {str(e)}"}
     except Exception as e:
         return {"error": str(e)}
-
 
 async def _check_comfyui_connection(url: Optional[str] = None) -> dict:
     """Check if ComfyUI is reachable.
@@ -261,7 +252,6 @@ async def _check_comfyui_connection(url: Optional[str] = None) -> dict:
         logger.exception("Unexpected error checking ComfyUI connection at %s", base_url)
         return {"connected": False, "url": base_url, "error": f"Unexpected error: {type(exc).__name__}"}
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -271,11 +261,9 @@ class ExecuteRequest(BaseModel):
     entity_id: Optional[str] = None
     input_overrides: Optional[dict] = None
 
-
 class ImportURLRequest(BaseModel):
     url: str
     filename: Optional[str] = None
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -303,7 +291,6 @@ async def status():
         "total_executions": hist_result["total"],
     }
 
-
 @router.get("/connect")
 async def connect(url: Optional[str] = None):
     """Test connectivity to the ComfyUI server.
@@ -322,7 +309,6 @@ async def connect(url: Optional[str] = None):
         version   (str?)   – ComfyUI version string when connected=true
     """
     return await _check_comfyui_connection(url=url)
-
 
 @router.get("/workflows")
 async def list_workflows(category: Optional[str] = None, search: Optional[str] = None):
@@ -364,7 +350,6 @@ async def list_workflows(category: Optional[str] = None, search: Optional[str] =
         "workflows_dir": str(workflows_dir),
     }
 
-
 @router.get("/workflows/{workflow_id}")
 async def get_workflow(workflow_id: str):
     """Get detailed information about a specific workflow."""
@@ -384,7 +369,6 @@ async def get_workflow(workflow_id: str):
         pass
 
     return wf
-
 
 @router.post("/import")
 async def import_workflow(
@@ -458,7 +442,6 @@ async def import_workflow(
 
     else:
         raise HTTPException(status_code=400, detail="Provide either a file upload or a URL")
-
 
 @router.post("/execute")
 async def execute_workflow(req: ExecuteRequest):
@@ -583,7 +566,6 @@ async def execute_workflow(req: ExecuteRequest):
         "message": f"Workflow '{req.workflow_id}' queued on ComfyUI",
     }
 
-
 @router.get("/queue")
 async def get_queue():
     """Get current ComfyUI execution queue."""
@@ -600,7 +582,6 @@ async def get_queue():
         "running_details": running,
         "pending_details": pending,
     }
-
 
 @router.get("/history")
 async def get_history(
@@ -622,7 +603,6 @@ async def get_history(
         items = [h for h in items if h.get("workflow_id") == workflow_id]
 
     return {"total": len(items), "items": items[:limit]}
-
 
 @router.get("/outputs/{entity_type}/{entity_id}")
 async def get_outputs(entity_type: str, entity_id: str):
@@ -658,7 +638,6 @@ async def get_outputs(entity_type: str, entity_id: str):
         "execution_count": len(entity_history),
     }
 
-
 @router.get("/comfyui/history")
 async def get_comfyui_history(limit: int = 20):
     """Get recent execution history from ComfyUI itself."""
@@ -692,7 +671,6 @@ async def get_comfyui_history(limit: int = 20):
 
     return {"items": items}
 
-
 @router.post("/migrate")
 async def migrate_legacy_data():
     """One-time migration of execution_history.json to database."""
@@ -701,7 +679,6 @@ async def migrate_legacy_data():
         return {"migrated": 0, "message": "No legacy data found"}
     count = data_svc.import_from_json(str(legacy_file))
     return {"migrated": count, "message": f"Migrated {count} records"}
-
 
 @router.get("/comfyui/view")
 async def view_comfyui_image(filename: str, subfolder: str = "", type: str = "output"):

--- a/plugins/comparison/backend/routes.py
+++ b/plugins/comparison/backend/routes.py
@@ -14,7 +14,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from difflib import unified_diff
 
 from fastapi import APIRouter, HTTPException
@@ -44,7 +44,6 @@ ENTITY_MAP = {
     "assembly":   ("Assemblies",  "ASSM_"),
 }
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -57,7 +56,6 @@ def _entity_file(entity_type: str, entity_id: str) -> Path:
     folder, prefix = mapping
     return BRAINS_ROOT / folder / entity_id / f"{prefix}{entity_id}.md"
 
-
 def _relative_path(full_path: Path) -> str:
     """Return the path relative to BRAINS_ROOT."""
     try:
@@ -65,7 +63,6 @@ def _relative_path(full_path: Path) -> str:
     except ValueError:
         # Path is not under BRAINS_ROOT, return absolute path
         return str(full_path)
-
 
 async def _run_git(*args: str, check: bool = True, cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
     """Run a git command asynchronously."""
@@ -89,7 +86,6 @@ async def _run_git(*args: str, check: bool = True, cwd: Optional[Path] = None) -
         logger.error("git error: %s", result.stderr.strip())
         raise HTTPException(status_code=500, detail=f"Git error: {result.stderr.strip()}")
     return result
-
 
 def _parse_markdown_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
     """Parse YAML frontmatter and markdown body from a markdown file."""
@@ -123,7 +119,6 @@ def _parse_markdown_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
 
     return frontmatter, body
 
-
 async def _get_entity_content(entity_type: str, entity_id: str, commit_sha: Optional[str] = None) -> Dict[str, Any]:
     """Get entity content from file or git history."""
     entity_path = _entity_file(entity_type, entity_id)
@@ -143,7 +138,6 @@ async def _get_entity_content(entity_type: str, entity_id: str, commit_sha: Opti
     content = entity_path.read_text(encoding="utf-8")
     return _parse_markdown_frontmatter(content)
 
-
 async def _get_git_diff(commit1: str, commit2: str, file_path: str, cwd: Path, context: int = 3) -> str:
     """Get unified diff between two commits for a file."""
     try:
@@ -161,7 +155,6 @@ async def _get_git_diff(commit1: str, commit2: str, file_path: str, cwd: Path, c
     except Exception:
         return ""
 
-
 # ---------------------------------------------------------------------------
 # Route Models
 # ---------------------------------------------------------------------------
@@ -171,18 +164,15 @@ class EntityComparisonRequest(BaseModel):
     entity_id1: str
     entity_id2: str
 
-
 class VersionComparisonRequest(BaseModel):
     entity_type: str
     entity_id: str
     commit1: str
     commit2: str
 
-
 class TemplateComparisonRequest(BaseModel):
     entity_type: str
     entity_id: str
-
 
 # ---------------------------------------------------------------------------
 # Comparison Routes
@@ -197,7 +187,6 @@ async def index():
         "status": "ok",
         "brains_root": str(BRAINS_ROOT),
     }
-
 
 @router.post("/compare/entities")
 async def compare_entities(request: EntityComparisonRequest):
@@ -281,7 +270,6 @@ async def compare_entities(request: EntityComparisonRequest):
             "fields_removed": len([k for k, v in field_diffs.items() if v["status"] == "removed"]),
         },
     }
-
 
 @router.post("/compare/versions")
 async def compare_versions(request: VersionComparisonRequest):
@@ -367,7 +355,6 @@ async def compare_versions(request: VersionComparisonRequest):
             "fields_removed": len([k for k, v in field_diffs.items() if v["status"] == "removed"]),
         },
     }
-
 
 @router.post("/compare/template")
 async def compare_template(request: TemplateComparisonRequest):
@@ -464,7 +451,6 @@ async def compare_template(request: TemplateComparisonRequest):
             "template_defaults_used": template_defaults_used,
         },
     }
-
 
 @router.post("/compare/batch")
 async def compare_batch(request: EntityComparisonRequest):

--- a/plugins/discord-poster/backend/routes.py
+++ b/plugins/discord-poster/backend/routes.py
@@ -7,7 +7,7 @@ managing webhook configurations, and tracking post history.
 
 import json
 import logging
-import os
+
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,7 +31,6 @@ BACKEND_URL = "http://localhost:8201"
 from services.plugin_data_service import PluginDataService
 
 data_svc = PluginDataService("discord-poster")
-
 
 # ---------------------------------------------------------------------------
 # Settings helpers
@@ -63,11 +62,9 @@ def _get_webhooks() -> list[dict]:
 
     return webhooks
 
-
 def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("discord-poster").get(key, default)
-
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -79,10 +76,8 @@ class PostRequest(BaseModel):
     message: Optional[str] = None
     include_image: bool = True
 
-
 class TestWebhookRequest(BaseModel):
     webhook_url: str
-
 
 # ---------------------------------------------------------------------------
 # Discord embed builder
@@ -95,7 +90,6 @@ def _hex_to_int(hex_color: str) -> int:
     except ValueError:
         return 0x5865F2  # Discord blurple fallback
 
-
 async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
     """Fetch entity data from the backend API."""
     async with httpx.AsyncClient(timeout=10) as client:
@@ -106,7 +100,6 @@ async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
                 detail=f"Failed to fetch entity {entity_type}/{entity_id}",
             )
         return resp.json()
-
 
 def _build_embed(entity: dict, entity_type: str, entity_id: str,
                  message: str | None = None, include_image: bool = True) -> dict:
@@ -182,7 +175,6 @@ def _build_embed(entity: dict, entity_type: str, entity_id: str,
 
     return embed
 
-
 async def _post_to_discord(webhook_url: str, embed: dict, bot_username: str | None = None,
                            bot_avatar: str | None = None) -> dict:
     """Post an embed to a Discord webhook. Returns status info."""
@@ -212,7 +204,6 @@ async def _post_to_discord(webhook_url: str, embed: dict, bot_username: str | No
                 "detail": str(exc),
             }
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -233,7 +224,6 @@ async def status():
         "auto_post_on_create": settings.get("auto_post_on_create", False),
         "auto_post_on_update": settings.get("auto_post_on_update", False),
     }
-
 
 @router.post("/post")
 async def post_to_discord(req: PostRequest):
@@ -297,7 +287,6 @@ async def post_to_discord(req: PostRequest):
         "history_id": history_entry["id"],
     }
 
-
 @router.get("/history")
 async def get_history(entity_type: str | None = None, entity_id: str | None = None,
                       limit: int = 50):
@@ -309,7 +298,6 @@ async def get_history(entity_type: str | None = None, entity_id: str | None = No
     )
     items = [r["data"] for r in result["records"]]
     return {"total": result["total"], "items": items}
-
 
 @router.get("/webhooks")
 async def list_webhooks():
@@ -329,7 +317,6 @@ async def list_webhooks():
             "url": url,
         })
     return {"webhooks": masked}
-
 
 @router.post("/test-webhook")
 async def test_webhook(req: TestWebhookRequest):
@@ -356,7 +343,6 @@ async def test_webhook(req: TestWebhookRequest):
 
     return {"success": True, "message": "Test message sent successfully!"}
 
-
 @router.get("/entity-preview")
 async def entity_preview(entity_type: str, entity_id: str):
     """Get a preview of what the Discord embed would look like for an entity."""
@@ -366,7 +352,6 @@ async def entity_preview(entity_type: str, entity_id: str):
         "entity_name": entity.get("name") or entity.get("title") or "Unknown",
         "embed": embed,
     }
-
 
 @router.get("/stats")
 async def get_stats():
@@ -402,7 +387,6 @@ async def get_stats():
         "failed": failed,
         "most_posted": most_posted,
     }
-
 
 @router.post("/migrate")
 async def migrate_legacy_data():

--- a/plugins/entity-validator/backend/routes.py
+++ b/plugins/entity-validator/backend/routes.py
@@ -67,7 +67,6 @@ def _locate_schemas_dir() -> Path:
         "Set the STUDIOBRAIN_SCHEMAS_DIR environment variable to the absolute path."
     )
 
-
 _SCHEMAS_DIR = _locate_schemas_dir()
 
 # Map entity_type → schema file path
@@ -89,7 +88,6 @@ ENTITY_SCHEMAS: Dict[str, Path] = {
     "style_bible": _SCHEMAS_DIR / "style_bible.json",
 }
 
-
 def _load_schema(entity_type: str) -> Dict[str, Any]:
     """Load and return the JSON Schema dict for *entity_type*.
 
@@ -110,14 +108,12 @@ def _load_schema(entity_type: str) -> Dict[str, Any]:
     with schema_path.open(encoding="utf-8") as fh:
         return json.load(fh)
 
-
 def _load_base_schema() -> Dict[str, Any]:
     base_path = _SCHEMAS_DIR / "_base.json"
     if not base_path.exists():
         return {}
     with base_path.open(encoding="utf-8") as fh:
         return json.load(fh)
-
 
 # ---------------------------------------------------------------------------
 # Validation helper
@@ -136,7 +132,7 @@ def _validate_frontmatter(
         ``value``   — the offending value (omitted for missing required fields)
     """
     try:
-        import jsonschema
+
         from jsonschema import Draft202012Validator, RefResolver
     except ImportError:
         logger.warning(
@@ -203,7 +199,6 @@ def _validate_frontmatter(
 
     return errors
 
-
 # ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
@@ -213,25 +208,21 @@ class ValidateFrontmatterRequest(BaseModel):
     frontmatter: Dict[str, Any] = Field(..., description="Parsed YAML frontmatter as a dict.")
     strict: bool = Field(default=False, description="Reject unknown fields when True.")
 
-
 class ValidateMarkdownRequest(BaseModel):
     entity_type: str = Field(..., description="Entity type (e.g. 'character', 'item').")
     content: str = Field(..., description="Raw markdown string including YAML frontmatter.")
     strict: bool = Field(default=False, description="Reject unknown fields when True.")
-
 
 class ValidationError(BaseModel):
     field: str
     message: str
     value: Optional[Any] = None
 
-
 class ValidationResult(BaseModel):
     valid: bool
     entity_type: str
     errors: List[ValidationError] = Field(default_factory=list)
     warnings: List[str] = Field(default_factory=list)
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -264,7 +255,6 @@ def _parse_markdown_frontmatter(content: str) -> Dict[str, Any]:
         )
     return frontmatter
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -287,7 +277,6 @@ async def validate_frontmatter(req: ValidateFrontmatterRequest):
             },
         )
     return ValidationResult(valid=True, entity_type=req.entity_type)
-
 
 @router.post("/validate/markdown", response_model=ValidationResult, status_code=200)
 async def validate_markdown(req: ValidateMarkdownRequest):
@@ -314,7 +303,6 @@ async def validate_markdown(req: ValidateMarkdownRequest):
         )
     return ValidationResult(valid=True, entity_type=entity_type)
 
-
 @router.get("/schemas", status_code=200)
 async def list_schemas():
     """Return the list of registered entity-type schema IDs."""
@@ -323,13 +311,11 @@ async def list_schemas():
         "count": len(ENTITY_SCHEMAS),
     }
 
-
 @router.get("/schemas/{entity_type}", status_code=200)
 async def get_schema(entity_type: str):
     """Return the full JSON Schema for *entity_type*."""
     schema = _load_schema(entity_type)
     return schema
-
 
 @router.get("/health", status_code=200)
 async def health():

--- a/plugins/hello-world/backend/routes.py
+++ b/plugins/hello-world/backend/routes.py
@@ -10,7 +10,6 @@ import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -24,28 +23,23 @@ router = APIRouter()
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 DATA_FILE = DATA_DIR / "notes.json"
 
-
 def _ensure_data_file() -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     if not DATA_FILE.exists():
         DATA_FILE.write_text(json.dumps({}, indent=2))
-
 
 def _read_data() -> dict:
     _ensure_data_file()
     with open(DATA_FILE, "r", encoding="utf-8") as f:
         return json.load(f)
 
-
 def _write_data(data: dict) -> None:
     _ensure_data_file()
     with open(DATA_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, default=str)
 
-
 def _entity_key(entity_type: str, entity_id: str) -> str:
     return f"{entity_type}:{entity_id}"
-
 
 # ---------------------------------------------------------------------------
 # Request models
@@ -55,7 +49,6 @@ class AddNoteRequest(BaseModel):
     entity_type: str
     entity_id: str
     text: str
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -70,12 +63,10 @@ async def hello():
         "version": "1.0.0",
     }
 
-
 @router.get("/status")
 async def status():
     """Plugin health check."""
     return {"status": "ok", "plugin": "hello-world"}
-
 
 @router.get("/notes")
 async def get_notes(
@@ -86,7 +77,6 @@ async def get_notes(
     data = _read_data()
     key = _entity_key(entity_type, entity_id)
     return {"notes": data.get(key, [])}
-
 
 @router.post("/notes")
 async def add_note(req: AddNoteRequest):
@@ -105,7 +95,6 @@ async def add_note(req: AddNoteRequest):
     data[key].insert(0, note)
     _write_data(data)
     return note
-
 
 @router.delete("/notes/{note_id}")
 async def delete_note(

--- a/plugins/import-export-pipeline/backend/routes.py
+++ b/plugins/import-export-pipeline/backend/routes.py
@@ -12,14 +12,13 @@ Features:
 - AI-assisted merge conflict resolution
 """
 
-import asyncio
 import logging
 import os
 import re
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 from enum import Enum
 
@@ -56,7 +55,6 @@ ENTITY_MAP = {
     "layout": ("Layouts", "LAY_"),
 }
 
-
 # ============================================================================
 # Enums and Models
 # ============================================================================
@@ -70,7 +68,6 @@ class ImportFormat(str, Enum):
     VERSE = "verse"
     ZIP = "zip"
 
-
 class ExportFormat(str, Enum):
     MARKDOWN = "markdown"
     JSON = "json"
@@ -79,13 +76,11 @@ class ExportFormat(str, Enum):
     PDF = "pdf"
     DOCX = "docx"
 
-
 class ImportMode(str, Enum):
     CREATE = "create"
     REPLACE = "replace"
     UPDATE = "update"
     MERGE = "merge"
-
 
 class ProgressStage(str, Enum):
     PARSING = "parsing"
@@ -93,7 +88,6 @@ class ProgressStage(str, Enum):
     PROCESSING = "processing"
     WRITING = "writing"
     COMPLETED = "completed"
-
 
 class ImportOptions(BaseModel):
     """Options for import operations."""
@@ -108,7 +102,6 @@ class ImportOptions(BaseModel):
     ignore_errors: bool = Field(default=False, description="Continue on errors")
     profile_name: Optional[str] = Field(default=None, description="Profile to use for import")
 
-
 class ExportOptions(BaseModel):
     """Options for export operations."""
     format: ExportFormat = Field(default=ExportFormat.MARKDOWN, description="Export format")
@@ -119,13 +112,11 @@ class ExportOptions(BaseModel):
     flatten_hierarchy: bool = Field(default=False, description="Flatten nested structures")
     profile_name: Optional[str] = Field(default=None, description="Profile to use for export")
 
-
 class BatchOptions(BaseModel):
     """Options for batch operations."""
     batch_size: int = Field(default=50, ge=1, le=1000, description="Batch size for processing")
     parallel_workers: int = Field(default=4, ge=1, le=16, description="Number of parallel workers")
     progress_callback: Optional[str] = Field(default=None, description="Progress callback URL")
-
 
 class ProfileConfig(BaseModel):
     """Configuration for an import/export profile."""
@@ -135,7 +126,6 @@ class ProfileConfig(BaseModel):
     export_formats: List[ExportFormat] = Field(default_factory=list, description="Supported export formats")
     default_layout: str = Field(default="gdd_standard", description="Default layout")
     settings: Dict[str, Any] = Field(default_factory=dict, description="Profile-specific settings")
-
 
 class PipelineTask(BaseModel):
     """A task in the import/export pipeline."""
@@ -151,7 +141,6 @@ class PipelineTask(BaseModel):
     error: Optional[str] = Field(default=None, description="Error message if failed")
     warnings: List[str] = Field(default_factory=list, description="Warnings during processing")
 
-
 class ImportResponse(BaseModel):
     """Response from import operation."""
     status: str = Field(..., description="Operation status")
@@ -161,7 +150,6 @@ class ImportResponse(BaseModel):
     warnings: List[str] = Field(default_factory=list, description="Warnings")
     errors: List[str] = Field(default_factory=list, description="Errors")
 
-
 class ExportResponse(BaseModel):
     """Response from export operation."""
     status: str = Field(..., description="Operation status")
@@ -170,7 +158,6 @@ class ExportResponse(BaseModel):
     output_files: List[str] = Field(default_factory=list, description="Output file paths")
     warnings: List[str] = Field(default_factory=list, description="Warnings")
     errors: List[str] = Field(default_factory=list, description="Errors")
-
 
 # ============================================================================
 # Helper Functions
@@ -212,7 +199,6 @@ def _detect_format(content: str, filename: str) -> ImportFormat:
     # Default to markdown
     return ImportFormat.MARKDOWN
 
-
 def _parse_markdown_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
     """Parse YAML frontmatter and markdown body from content."""
     if not content.strip():
@@ -245,7 +231,6 @@ def _parse_markdown_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
 
     return frontmatter, body
 
-
 def _parse_json_content(content: str) -> tuple[Dict[str, Any], str]:
     """Parse JSON content."""
     import json
@@ -257,7 +242,6 @@ def _parse_json_content(content: str) -> tuple[Dict[str, Any], str]:
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON: {e}")
 
-
 def _parse_csv_content(content: str) -> tuple[List[Dict[str, Any]], str]:
     """Parse CSV content."""
     import csv
@@ -267,7 +251,6 @@ def _parse_csv_content(content: str) -> tuple[List[Dict[str, Any]], str]:
         return list(reader), ""
     except Exception as e:
         raise ValueError(f"Invalid CSV: {e}")
-
 
 def _parse_opml_content(content: str) -> tuple[Dict[str, Any], str]:
     """Parse OPML content (XML-based outline format)."""
@@ -289,7 +272,6 @@ def _parse_opml_content(content: str) -> tuple[Dict[str, Any], str]:
     except ET.ParseError as e:
         raise ValueError(f"Invalid OPML: {e}")
 
-
 def _parse_verse_content(content: str) -> tuple[Dict[str, Any], str]:
     """Parse Verse (UEFN) content."""
     # Verse files have specific patterns
@@ -306,7 +288,6 @@ def _parse_verse_content(content: str) -> tuple[Dict[str, Any], str]:
     except ValueError:
         return {"type": "verse_code", "content": content}, ""
 
-
 def _get_entity_folder(entity_type: str) -> Optional[Path]:
     """Get the data folder path for an entity type."""
     mapping = ENTITY_MAP.get(entity_type.lower())
@@ -315,7 +296,6 @@ def _get_entity_folder(entity_type: str) -> Optional[Path]:
     folder_name, _ = mapping
     return BRAINS_ROOT / folder_name
 
-
 def _entity_file_path(entity_type: str, entity_id: str) -> Path:
     """Get the file path for an entity."""
     mapping = ENTITY_MAP.get(entity_type.lower())
@@ -323,7 +303,6 @@ def _entity_file_path(entity_type: str, entity_id: str) -> Path:
         raise ValueError(f"Unknown entity type: {entity_type}")
     folder_name, prefix = mapping
     return BRAINS_ROOT / folder_name / entity_id / f"{prefix}{entity_id}.md"
-
 
 def _detect_entity_type_from_file(content: str, filename: str) -> Optional[str]:
     """Try to detect entity type from file content."""
@@ -349,7 +328,6 @@ def _detect_entity_type_from_file(content: str, filename: str) -> Optional[str]:
                 return entity_type
 
     return None
-
 
 # ============================================================================
 # Import Routes
@@ -380,7 +358,6 @@ async def pipeline_status():
             "auto_detection",
         ],
     }
-
 
 @router.post("/import/preview")
 async def preview_import(
@@ -466,7 +443,6 @@ async def preview_import(
 
     raise HTTPException(status_code=400, detail="Unknown file format")
 
-
 @router.post("/import/single", response_model=ImportResponse)
 async def import_single(
     file: UploadFile,
@@ -543,7 +519,6 @@ async def import_single(
     else:
         raise HTTPException(status_code=400, detail=f"Mode '{options.mode}' not yet implemented")
 
-
 @router.post("/import/batch", response_model=ImportResponse)
 async def import_batch(
     files: List[UploadFile],
@@ -600,7 +575,6 @@ async def import_batch(
         warnings=warnings,
         errors=errors,
     )
-
 
 @router.post("/import/zip", response_model=ImportResponse)
 async def import_zip(
@@ -674,7 +648,6 @@ async def import_zip(
         except zipfile.BadZipFile:
             raise HTTPException(status_code=400, detail="Invalid ZIP file")
 
-
 # ============================================================================
 # Export Routes
 # ============================================================================
@@ -721,7 +694,6 @@ async def export_markdown(
         output_files=output_files,
         errors=errors,
     )
-
 
 @router.post("/export/json", response_model=ExportResponse)
 async def export_json(
@@ -787,7 +759,6 @@ async def export_json(
         errors=errors,
     )
 
-
 @router.post("/export/csv", response_model=ExportResponse)
 async def export_csv(
     entity_type: str,
@@ -852,7 +823,6 @@ async def export_csv(
         output_files=output_files,
         errors=errors,
     )
-
 
 @router.post("/export/html", response_model=ExportResponse)
 async def export_html(
@@ -927,7 +897,6 @@ async def export_html(
         errors=errors,
     )
 
-
 @router.post("/export/pdf")
 async def export_pdf(
     entity_type: str,
@@ -939,7 +908,6 @@ async def export_pdf(
 
     Uses Playwright for high-quality PDF generation.
     """
-    import asyncio
 
     task_id = f"export-pdf-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
 
@@ -1033,7 +1001,6 @@ async def export_pdf(
         "errors": errors,
     }
 
-
 @router.post("/export/docx")
 async def export_docx(
     entity_type: str,
@@ -1111,7 +1078,6 @@ async def export_docx(
         "errors": errors,
     }
 
-
 # ============================================================================
 # Profile Management Routes
 # ============================================================================
@@ -1161,7 +1127,6 @@ async def list_profiles(
 
     return profiles
 
-
 @router.get("/profiles/{{profile_name}}", response_model=ProfileConfig)
 async def get_profile(profile_name: str):
     """
@@ -1174,7 +1139,6 @@ async def get_profile(profile_name: str):
             return profile
 
     raise HTTPException(status_code=404, detail=f"Profile not found: {profile_name}")
-
 
 # ============================================================================
 # System Routes
@@ -1203,7 +1167,6 @@ async def list_available_formats():
             {"format": "docx", "extensions": [".docx"], "description": "Microsoft Word document"},
         ],
     }
-
 
 @router.get("/auto-detect")
 async def detect_format(content: str, filename: str):

--- a/plugins/jira-sync/backend/events.py
+++ b/plugins/jira-sync/backend/events.py
@@ -8,13 +8,11 @@ The ``register_handlers`` function is called by the plugin loader when the
 plugin is enabled.
 """
 
-from __future__ import annotations
-
 import json
 import logging
-import time
+
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -25,7 +23,6 @@ DATA_DIR = PLUGIN_DIR / "data"
 LINKS_FILE = DATA_DIR / "entity_links.json"
 STUDIO_API = "http://localhost:8201/api"
 PLUGIN_API = "http://localhost:8201/api/ext/jira-sync"
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -39,25 +36,20 @@ def _load_json(path: Path, default: Any = None) -> Any:
     except Exception:
         return default if default is not None else {}
 
-
 def _read_settings() -> Dict[str, Any]:
     settings_file = PLUGIN_DIR.parent / "_plugin_settings.json"
     all_settings = _load_json(settings_file, {})
     return all_settings.get("jira-sync", {})
 
-
 def _jira_configured() -> bool:
     s = _read_settings()
     return bool(s.get("jira_instance_url") and s.get("jira_api_token"))
 
-
 def _link_key(entity_type: str, entity_id: str) -> str:
     return f"{entity_type}:{entity_id}"
 
-
 def _load_links() -> Dict[str, Any]:
     return _load_json(LINKS_FILE, {})
-
 
 # ---------------------------------------------------------------------------
 # Event registration

--- a/plugins/jira-sync/backend/routes.py
+++ b/plugins/jira-sync/backend/routes.py
@@ -9,17 +9,15 @@ When Jira credentials are not configured the endpoints return helpful mock
 responses with setup instructions so the frontend can still render.
 """
 
-from __future__ import annotations
-
 import json
 import logging
-import os
+
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Body, Query
+from fastapi import APIRouter, HTTPException, Body
 
 router = APIRouter()
 logger = logging.getLogger("plugin.jira-sync")
@@ -41,7 +39,6 @@ STUDIO_API = "http://localhost:8201/api"
 def _ensure_data_dir() -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-
 def _load_json(path: Path, default: Any = None) -> Any:
     _ensure_data_dir()
     if not path.exists():
@@ -51,31 +48,24 @@ def _load_json(path: Path, default: Any = None) -> Any:
     except Exception:
         return default if default is not None else {}
 
-
 def _save_json(path: Path, data: Any) -> None:
     _ensure_data_dir()
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-
 def _load_links() -> Dict[str, Any]:
     return _load_json(LINKS_FILE, {})
-
 
 def _save_links(links: Dict[str, Any]) -> None:
     _save_json(LINKS_FILE, links)
 
-
 def _load_mappings() -> Dict[str, Any]:
     return _load_json(MAPPINGS_FILE, {"default": {"name": "summary", "description": "description", "production_status": "status"}})
-
 
 def _save_mappings(mappings: Dict[str, Any]) -> None:
     _save_json(MAPPINGS_FILE, mappings)
 
-
 def _link_key(entity_type: str, entity_id: str) -> str:
     return f"{entity_type}:{entity_id}"
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- settings access
@@ -87,11 +77,9 @@ def _read_settings() -> Dict[str, Any]:
     all_settings = _load_json(settings_file, {})
     return all_settings.get("jira-sync", {})
 
-
 def _jira_configured() -> bool:
     s = _read_settings()
     return bool(s.get("jira_instance_url") and s.get("jira_api_token"))
-
 
 def _jira_headers() -> Dict[str, str]:
     s = _read_settings()
@@ -99,7 +87,6 @@ def _jira_headers() -> Dict[str, str]:
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
-
 
 def _jira_auth() -> Optional[tuple]:
     s = _read_settings()
@@ -109,12 +96,10 @@ def _jira_auth() -> Optional[tuple]:
         return (email, token)
     return None
 
-
 def _jira_base_url() -> str:
     s = _read_settings()
     url = s.get("jira_instance_url", "").rstrip("/")
     return url
-
 
 def _entity_type_to_issue_type(entity_type: str) -> str:
     s = _read_settings()
@@ -125,7 +110,6 @@ def _entity_type_to_issue_type(entity_type: str) -> str:
         mapping = {}
     return mapping.get(entity_type, "Task")
 
-
 def _status_mapping() -> Dict[str, str]:
     s = _read_settings()
     mapping_raw = s.get("status_field_mapping", '{"draft":"To Do","in_progress":"In Progress","review":"In Review","complete":"Done"}')
@@ -134,17 +118,14 @@ def _status_mapping() -> Dict[str, str]:
     except Exception:
         return {}
 
-
 def _default_labels() -> list:
     s = _read_settings()
     raw = s.get("labels", "city-of-brains,auto-created")
     return [l.strip() for l in raw.split(",") if l.strip()]
 
-
 def _project_key() -> str:
     s = _read_settings()
     return s.get("default_project_key", "PROJ")
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- Jira REST calls
@@ -160,7 +141,6 @@ async def _jira_request(method: str, path: str, **kwargs) -> httpx.Response:
         )
     return resp
 
-
 async def _fetch_entity(entity_type: str, entity_id: str) -> Dict[str, Any]:
     """Fetch an entity from the Studio backend."""
     url = f"{STUDIO_API}/entity/{entity_type}/{entity_id}"
@@ -169,7 +149,6 @@ async def _fetch_entity(entity_type: str, entity_id: str) -> Dict[str, Any]:
     if resp.status_code != 200:
         raise HTTPException(status_code=404, detail=f"Entity {entity_type}/{entity_id} not found")
     return resp.json()
-
 
 async def _create_jira_issue(entity: Dict[str, Any], entity_type: str) -> Dict[str, Any]:
     """Create a Jira issue from a Studio entity."""
@@ -203,14 +182,12 @@ async def _create_jira_issue(entity: Dict[str, Any], entity_type: str) -> Dict[s
 
     return resp.json()
 
-
 async def _get_jira_issue(issue_key: str) -> Dict[str, Any]:
     """Fetch a Jira issue by key."""
     resp = await _jira_request("GET", f"/issue/{issue_key}")
     if resp.status_code != 200:
         raise HTTPException(status_code=502, detail=f"Jira issue {issue_key} not found")
     return resp.json()
-
 
 async def _transition_jira_issue(issue_key: str, target_status: str) -> bool:
     """Attempt to transition a Jira issue to the given status name."""
@@ -237,7 +214,6 @@ async def _transition_jira_issue(issue_key: str, target_status: str) -> bool:
         json={"transition": {"id": match["id"]}},
     )
     return resp.status_code == 204
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -283,7 +259,6 @@ async def root():
 
     return info
 
-
 @router.get("/status")
 async def sync_status():
     """Sync overview: counts of linked entities, sync errors, etc."""
@@ -313,7 +288,6 @@ async def sync_status():
         "auto_transition": settings.get("auto_transition_on_status", True),
         "jira_configured": _jira_configured(),
     }
-
 
 # ---------------------------------------------------------------------------
 # Sync entity <-> Jira
@@ -409,7 +383,6 @@ async def sync_entity(entity_type: str, entity_id: str):
         except Exception as exc:
             raise HTTPException(status_code=502, detail=str(exc))
 
-
 # ---------------------------------------------------------------------------
 # Link management
 # ---------------------------------------------------------------------------
@@ -457,7 +430,6 @@ async def get_link(entity_type: str, entity_id: str):
 
     return result
 
-
 @router.post("/link/{entity_type}/{entity_id}")
 async def create_link(entity_type: str, entity_id: str, body: dict = Body(...)):
     """Manually link an entity to an existing Jira issue."""
@@ -494,7 +466,6 @@ async def create_link(entity_type: str, entity_id: str, body: dict = Body(...)):
         "issue_url": f"{_jira_base_url()}/browse/{issue_key}" if _jira_configured() else None,
     }
 
-
 @router.delete("/link/{entity_type}/{entity_id}")
 async def delete_link(entity_type: str, entity_id: str):
     """Unlink an entity from its Jira issue."""
@@ -513,7 +484,6 @@ async def delete_link(entity_type: str, entity_id: str):
         "entity_id": entity_id,
         "removed_issue_key": removed.get("issue_key"),
     }
-
 
 # ---------------------------------------------------------------------------
 # Bulk sync
@@ -585,7 +555,6 @@ async def sync_all(entity_type: str):
     _save_links(links)
     return results
 
-
 # ---------------------------------------------------------------------------
 # Field mappings
 # ---------------------------------------------------------------------------
@@ -595,13 +564,11 @@ async def get_mappings():
     """Get entity-to-Jira field mappings."""
     return _load_mappings()
 
-
 @router.put("/mappings")
 async def update_mappings(body: dict = Body(...)):
     """Update entity-to-Jira field mappings."""
     _save_mappings(body)
     return {"status": "saved", "mappings": body}
-
 
 # ---------------------------------------------------------------------------
 # Webhook receiver (for bidirectional sync)

--- a/plugins/lora-trainer/backend/routes.py
+++ b/plugins/lora-trainer/backend/routes.py
@@ -8,7 +8,7 @@ linked to character entities.
 
 import json
 import logging
-import os
+
 import re
 import time
 import uuid
@@ -41,7 +41,6 @@ BACKEND_URL = "http://localhost:8201"
 # Supported training image extensions
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff"}
 
-
 # ---------------------------------------------------------------------------
 # Settings helpers
 # ---------------------------------------------------------------------------
@@ -49,13 +48,11 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("lora-trainer").get(key, default)
 
-
 def _output_dir() -> Path:
     """Return the configured LoRA output directory, creating it if needed."""
     p = Path(_get_setting("output_dir", "A:/Brains/_Generated/loras"))
     p.mkdir(parents=True, exist_ok=True)
     return p
-
 
 # ---------------------------------------------------------------------------
 # Entity helpers
@@ -67,11 +64,9 @@ def _entity_dir(entity_type: str, entity_id: str) -> Path:
     type_folder = type_folder[0].upper() + type_folder[1:]
     return BRAINS_ROOT / type_folder / entity_id
 
-
 def _entity_assets_dir(entity_type: str, entity_id: str) -> Path:
     """Return the assets directory for an entity."""
     return _entity_dir(entity_type, entity_id) / "assets"
-
 
 def _parse_frontmatter(filepath: Path) -> dict:
     """Read a markdown file and extract YAML frontmatter as a dict."""
@@ -92,7 +87,6 @@ def _parse_frontmatter(filepath: Path) -> dict:
                 key, _, val = line.partition(":")
                 data[key.strip()] = val.strip().strip("'\"")
         return data
-
 
 def _get_entity_metadata(entity_type: str, entity_id: str) -> dict:
     """Try to load entity metadata from its markdown file."""
@@ -121,7 +115,6 @@ def _get_entity_metadata(entity_type: str, entity_id: str) -> dict:
             return fm
     return {}
 
-
 # ---------------------------------------------------------------------------
 # Job persistence
 # ---------------------------------------------------------------------------
@@ -134,11 +127,9 @@ def _load_jobs() -> list[dict]:
         pass
     return []
 
-
 def _save_jobs(jobs: list[dict]):
     PLUGIN_DATA.mkdir(parents=True, exist_ok=True)
     JOBS_FILE.write_text(json.dumps(jobs, indent=2, default=str), encoding="utf-8")
-
 
 def _find_job(job_id: str) -> Optional[dict]:
     jobs = _load_jobs()
@@ -147,7 +138,6 @@ def _find_job(job_id: str) -> Optional[dict]:
             return j
     return None
 
-
 def _update_job(job_id: str, updates: dict):
     jobs = _load_jobs()
     for j in jobs:
@@ -155,7 +145,6 @@ def _update_job(job_id: str, updates: dict):
             j.update(updates)
             break
     _save_jobs(jobs)
-
 
 # ---------------------------------------------------------------------------
 # LoRA index persistence
@@ -169,10 +158,8 @@ def _load_lora_index() -> list[dict]:
         pass
     return []
 
-
 def _save_lora_index(index: list[dict]):
     LORA_INDEX_FILE.write_text(json.dumps(index, indent=2, default=str), encoding="utf-8")
-
 
 def _scan_lora_files() -> list[dict]:
     """Scan the output directory for .safetensors files and merge with index."""
@@ -202,7 +189,6 @@ def _scan_lora_files() -> list[dict]:
     found.sort(key=lambda x: x.get("created", ""), reverse=True)
     return found
 
-
 # ---------------------------------------------------------------------------
 # Caption helpers
 # ---------------------------------------------------------------------------
@@ -214,7 +200,6 @@ def _caption_file_for(entity_type: str, entity_id: str, image_name: str) -> Path
     stem = Path(image_name).stem
     return safe_dir / f"{stem}.txt"
 
-
 def _get_caption(entity_type: str, entity_id: str, image_name: str) -> str:
     """Load caption for an image, or return empty string."""
     cf = _caption_file_for(entity_type, entity_id, image_name)
@@ -222,12 +207,10 @@ def _get_caption(entity_type: str, entity_id: str, image_name: str) -> str:
         return cf.read_text(encoding="utf-8").strip()
     return ""
 
-
 def _set_caption(entity_type: str, entity_id: str, image_name: str, caption: str):
     """Save caption for an image."""
     cf = _caption_file_for(entity_type, entity_id, image_name)
     cf.write_text(caption.strip(), encoding="utf-8")
-
 
 def _generate_caption_from_metadata(metadata: dict, entity_type: str, entity_id: str) -> str:
     """Build a training caption string from entity metadata."""
@@ -268,7 +251,6 @@ def _generate_caption_from_metadata(metadata: dict, entity_type: str, entity_id:
 
     return ", ".join(parts)
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -278,15 +260,12 @@ class TrainRequest(BaseModel):
     entity_id: str
     config: dict = Field(default_factory=lambda: {})
 
-
 class CaptionUpdate(BaseModel):
     image_name: str
     caption: str
 
-
 class CaptionBulkUpdate(BaseModel):
     captions: list[CaptionUpdate]
-
 
 # ---------------------------------------------------------------------------
 # Mock training progress simulation
@@ -344,7 +323,6 @@ def _simulate_progress(job: dict) -> dict:
 
     return job
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -378,7 +356,6 @@ async def plugin_status():
         "loras_available": len(loras),
         "gpu_id": settings.get("gpu_id", 0),
     }
-
 
 @router.get("/datasets/{entity_type}/{entity_id}")
 async def list_dataset_images(entity_type: str, entity_id: str):
@@ -422,7 +399,6 @@ async def list_dataset_images(entity_type: str, entity_id: str):
         "total": len(images),
         "captioned": sum(1 for img in images if img["has_caption"]),
     }
-
 
 @router.post("/datasets/{entity_type}/{entity_id}/prepare")
 async def prepare_dataset(entity_type: str, entity_id: str):
@@ -477,7 +453,6 @@ async def prepare_dataset(entity_type: str, entity_id: str):
         "trigger_word": entity_id.replace("_", " ").replace("-", " "),
     }
 
-
 @router.post("/datasets/{entity_type}/{entity_id}/captions")
 async def update_captions(entity_type: str, entity_id: str, body: CaptionBulkUpdate):
     """Update captions for multiple images at once."""
@@ -487,7 +462,6 @@ async def update_captions(entity_type: str, entity_id: str, body: CaptionBulkUpd
         updated += 1
 
     return {"success": True, "updated": updated}
-
 
 @router.post("/train")
 async def queue_training(req: TrainRequest):
@@ -569,7 +543,6 @@ async def queue_training(req: TrainRequest):
         "image_count": image_count,
     }
 
-
 @router.get("/jobs")
 async def list_jobs(
     status: Optional[str] = Query(None),
@@ -596,7 +569,6 @@ async def list_jobs(
         "total": len(jobs),
     }
 
-
 @router.get("/jobs/{job_id}")
 async def get_job(job_id: str):
     """Get details and progress for a specific training job."""
@@ -610,7 +582,6 @@ async def get_job(job_id: str):
         _update_job(job_id, job)
 
     return job
-
 
 @router.post("/jobs/{job_id}/cancel")
 async def cancel_job(job_id: str):
@@ -631,7 +602,6 @@ async def cancel_job(job_id: str):
     logger.info("Cancelled training job %s", job_id)
     return {"success": True, "message": "Training job cancelled"}
 
-
 @router.delete("/jobs/{job_id}")
 async def delete_job(job_id: str):
     """Remove a job from the queue history."""
@@ -646,7 +616,6 @@ async def delete_job(job_id: str):
     logger.info("Deleted training job %s", job_id)
     return {"success": True, "message": "Training job removed from history"}
 
-
 @router.get("/loras")
 async def list_loras():
     """List all completed LoRA files in the output directory."""
@@ -656,7 +625,6 @@ async def list_loras():
         "total": len(loras),
         "output_dir": str(_output_dir()),
     }
-
 
 @router.get("/loras/{entity_type}/{entity_id}")
 async def get_entity_loras(entity_type: str, entity_id: str):
@@ -687,7 +655,6 @@ async def get_entity_loras(entity_type: str, entity_id: str):
         "active_jobs": active_jobs,
         "has_lora": len(entity_loras) > 0 or len(completed_jobs) > 0,
     }
-
 
 @router.get("/gpu-status")
 async def gpu_status():

--- a/plugins/music-gen/backend/routes.py
+++ b/plugins/music-gen/backend/routes.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.music-gen")
 
@@ -41,7 +41,6 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("music-gen").get(key, default)
 
-
 def _get_api_key(provider: str = None) -> Optional[str]:
     """Get the API key for the specified or default provider."""
     from services.plugin_settings_service import get_all_settings
@@ -52,7 +51,6 @@ def _get_api_key(provider: str = None) -> Optional[str]:
     elif prov == "udio":
         return settings.get("udio_api_key") or None
     return None
-
 
 # ---------------------------------------------------------------------------
 # Track data persistence
@@ -67,7 +65,6 @@ def _load_tracks() -> list[dict]:
         pass
     return []
 
-
 def _save_tracks(tracks: list[dict]):
     """Save track metadata, keeping last 1000 entries."""
     TRACKS_FILE.write_text(
@@ -75,13 +72,11 @@ def _save_tracks(tracks: list[dict]):
         encoding="utf-8",
     )
 
-
 def _add_track(track: dict):
     """Append a track entry to the data file."""
     tracks = _load_tracks()
     tracks.append(track)
     _save_tracks(tracks)
-
 
 def _remove_track(track_id: str) -> bool:
     """Remove a track by ID. Returns True if found and removed."""
@@ -92,7 +87,6 @@ def _remove_track(track_id: str) -> bool:
         _save_tracks(tracks)
         return True
     return False
-
 
 # ---------------------------------------------------------------------------
 # Entity helpers
@@ -106,12 +100,10 @@ def _entity_assets_dir(entity_type: str, entity_id: str) -> Path:
     assets.mkdir(parents=True, exist_ok=True)
     return assets
 
-
 def _type_folder(entity_type: str) -> str:
     """Convert entity type to folder name (character -> Characters)."""
     folder = entity_type.rstrip("s") + "s"
     return folder[0].upper() + folder[1:]
-
 
 async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
     """Fetch entity data from the backend API."""
@@ -123,7 +115,6 @@ async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
                 detail=f"Failed to fetch entity {entity_type}/{entity_id}",
             )
         return resp.json()
-
 
 # ---------------------------------------------------------------------------
 # Prompt generation helpers
@@ -240,7 +231,6 @@ def _build_auto_prompt(entity: dict, entity_type: str) -> dict:
         "entity_name": name,
     }
 
-
 # ---------------------------------------------------------------------------
 # Mock generation (when no API key is configured)
 # ---------------------------------------------------------------------------
@@ -279,7 +269,6 @@ def _generate_mock_track(prompt: str, duration: int, genre: str,
 
     _add_track(track)
     return track
-
 
 def _write_silent_placeholder(filepath: Path, fmt: str, duration: int):
     """
@@ -322,7 +311,6 @@ def _write_silent_placeholder(filepath: Path, fmt: str, duration: int):
         total_frames = frames_per_sec * max(duration, 1)
         filepath.write_bytes(frame * total_frames)
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -334,7 +322,6 @@ class GenerateRequest(BaseModel):
     mood: Optional[str] = None
     entity_type: str = "character"
     entity_id: str = ""
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -360,7 +347,6 @@ async def plugin_status():
         "default_genre": _get_setting("default_genre", "ambient"),
         "total_tracks": len(tracks),
     }
-
 
 @router.post("/generate")
 async def generate_music(req: GenerateRequest):
@@ -459,7 +445,6 @@ async def generate_music(req: GenerateRequest):
         "mock": False,
     }
 
-
 async def _generate_via_suno(api_key: str, prompt: str, duration: int,
                               genre: str, mood: Optional[str]) -> bytes:
     """Call Suno API to generate music. Returns raw audio bytes."""
@@ -499,7 +484,6 @@ async def _generate_via_suno(api_key: str, prompt: str, duration: int,
             raise HTTPException(status_code=502, detail="Failed to download audio from Suno")
         return audio_resp.content
 
-
 async def _generate_via_udio(api_key: str, prompt: str, duration: int,
                               genre: str, mood: Optional[str]) -> bytes:
     """Call Udio API to generate music. Returns raw audio bytes."""
@@ -538,7 +522,6 @@ async def _generate_via_udio(api_key: str, prompt: str, duration: int,
             raise HTTPException(status_code=502, detail="Failed to download audio from Udio")
         return audio_resp.content
 
-
 @router.post("/auto-prompt/{entity_type}/{entity_id}")
 async def auto_generate_prompt(entity_type: str, entity_id: str):
     """
@@ -554,7 +537,6 @@ async def auto_generate_prompt(entity_type: str, entity_id: str):
         "entity_id": entity_id,
         **result,
     }
-
 
 @router.get("/tracks/{entity_type}/{entity_id}")
 async def get_entity_tracks(entity_type: str, entity_id: str):
@@ -595,14 +577,12 @@ async def get_entity_tracks(entity_type: str, entity_id: str):
         "count": len(entity_tracks),
     }
 
-
 def _parse_genre_from_filename(filename: str) -> str:
     """Extract genre from filename like music_ambient_1234_abcd.mp3"""
     parts = filename.replace("music_", "").split("_")
     if parts:
         return parts[0].replace("-", " ")
     return "unknown"
-
 
 @router.get("/library")
 async def get_library(limit: int = 100, genre: Optional[str] = None):
@@ -640,7 +620,6 @@ async def get_library(limit: int = 100, genre: Optional[str] = None):
             "entity_types": entity_types,
         },
     }
-
 
 @router.delete("/tracks/{track_id}")
 async def delete_track(track_id: str):

--- a/plugins/obsidian-vault/backend/routes.py
+++ b/plugins/obsidian-vault/backend/routes.py
@@ -11,14 +11,13 @@ import logging
 import os
 import re
 import shutil
-import time
+
 from datetime import datetime, timezone
-from pathlib import Path
+
 from typing import Any, Dict, List, Optional
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.obsidian-vault")
@@ -62,7 +61,6 @@ SINGLE_REF_FIELDS = [
     "primary_brand", "faction_control",
 ]
 
-
 # ---------------------------------------------------------------------------
 # Helpers -- settings
 # ---------------------------------------------------------------------------
@@ -81,7 +79,6 @@ def _load_settings() -> Dict[str, Any]:
     defaults.update({k: v for k, v in stored.items() if k in defaults})
     return defaults
 
-
 def _save_settings(settings: Dict[str, Any]):
     """Persist plugin settings."""
     try:
@@ -95,7 +92,6 @@ def _save_settings(settings: Dict[str, Any]):
     with open(SETTINGS_FILE, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
 
-
 def _get_vault_path() -> str:
     """Return validated vault path or raise."""
     settings = _load_settings()
@@ -103,7 +99,6 @@ def _get_vault_path() -> str:
     if not vault_path:
         raise HTTPException(status_code=400, detail="Vault path not configured. Set it in plugin settings.")
     return vault_path
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- export log
@@ -116,11 +111,9 @@ def _load_export_log() -> Dict[str, Any]:
     except Exception:
         return {}
 
-
 def _save_export_log(log: Dict[str, Any]):
     with open(EXPORT_LOG_FILE, "w", encoding="utf-8") as fh:
         json.dump(log, fh, indent=2)
-
 
 def _record_export(entity_type: str, entity_id: str, link_count: int, vault_file: str):
     log = _load_export_log()
@@ -131,7 +124,6 @@ def _record_export(entity_type: str, entity_id: str, link_count: int, vault_file
         "vault_file": vault_file,
     }
     _save_export_log(log)
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- entity loading
@@ -156,7 +148,6 @@ def _find_entity_file(entity_type: str, entity_id: str) -> Optional[str]:
             return os.path.join(entity_dir, fname)
     return None
 
-
 def _parse_entity_file(filepath: str) -> Dict[str, Any]:
     """Parse a City of Brains entity markdown file, returning frontmatter + body."""
     with open(filepath, "r", encoding="utf-8") as fh:
@@ -176,7 +167,6 @@ def _parse_entity_file(filepath: str) -> Dict[str, Any]:
 
     return {"frontmatter": frontmatter, "body": body, "raw": content}
 
-
 def _get_entity_images_dir(entity_type: str, entity_id: str) -> Optional[str]:
     """Return path to entity images directory if it exists."""
     mapping = ENTITY_TYPE_MAP.get(entity_type)
@@ -188,14 +178,12 @@ def _get_entity_images_dir(entity_type: str, entity_id: str) -> Optional[str]:
         return images_dir
     return None
 
-
 # ---------------------------------------------------------------------------
 # Helpers -- name resolution
 # ---------------------------------------------------------------------------
 
 _entity_name_cache: Dict[str, str] = {}
 _cache_built = False
-
 
 def _build_name_cache():
     """Build a lookup of entity_id -> display name across all entity types."""
@@ -230,28 +218,23 @@ def _build_name_cache():
                 _entity_name_cache[eid] = _id_to_display_name(eid)
     _cache_built = True
 
-
 def _invalidate_name_cache():
     global _entity_name_cache, _cache_built
     _entity_name_cache = {}
     _cache_built = False
 
-
 def _clean_name(name: str) -> str:
     """Remove characters that Obsidian disallows in page titles."""
     return re.sub(r'[\\/:*?"<>|#\^\[\]]', '', name).strip()
-
 
 def _id_to_display_name(entity_id: str) -> str:
     """Convert snake_case id to Title Case display name."""
     return entity_id.replace("_", " ").title()
 
-
 def _resolve_name(entity_id: str) -> str:
     """Resolve an entity_id to a display name for wikilinks."""
     _build_name_cache()
     return _entity_name_cache.get(entity_id, _id_to_display_name(entity_id))
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- Obsidian conversion
@@ -265,7 +248,6 @@ def _make_link(name: str, link_style: str = "wikilink") -> str:
     else:
         safe = clean.replace(" ", "%20")
         return f"[{clean}]({safe}.md)"
-
 
 def _extract_names_from_relationship(items: Any) -> List[str]:
     """Pull entity names out of a relationship list (various formats)."""
@@ -281,7 +263,6 @@ def _extract_names_from_relationship(items: Any) -> List[str]:
     elif isinstance(items, str) and items:
         names.append(items)
     return names
-
 
 def _build_obsidian_frontmatter(fm: Dict[str, Any], entity_type: str) -> Dict[str, Any]:
     """Build Obsidian-optimized YAML frontmatter from entity frontmatter."""
@@ -369,7 +350,6 @@ def _build_obsidian_frontmatter(fm: Dict[str, Any], entity_type: str) -> Dict[st
         obs["cob_template_version"] = str(fm["template_version"])
 
     return obs
-
 
 def _convert_body_with_wikilinks(
     body: str,
@@ -466,7 +446,6 @@ def _convert_body_with_wikilinks(
 
     return converted_body, len(links_added)
 
-
 def _build_obsidian_markdown(
     entity_type: str,
     entity_id: str,
@@ -505,7 +484,6 @@ def _build_obsidian_markdown(
     md = f"---\n{fm_str}\n---\n\n{image_embed}{converted_body}\n"
 
     return md, link_count
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- writing to vault
@@ -569,7 +547,6 @@ def _write_to_vault(
         "images_copied": images_copied,
     }
 
-
 # ---------------------------------------------------------------------------
 # Helpers -- enumerate all entities
 # ---------------------------------------------------------------------------
@@ -599,7 +576,6 @@ def _enumerate_all_entities() -> List[Dict[str, str]]:
                 })
     return entities
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -617,7 +593,6 @@ async def index():
         "vault_exists": vault_exists,
         "settings": settings,
     }
-
 
 @router.get("/status")
 async def vault_status():
@@ -681,7 +656,6 @@ async def vault_status():
         "entities": results,
     }
 
-
 @router.get("/status/{entity_type}/{entity_id}")
 async def entity_export_status(entity_type: str, entity_id: str):
     """Check export status for a single entity."""
@@ -723,7 +697,6 @@ async def entity_export_status(entity_type: str, entity_id: str):
             "vault_file": "",
         }
 
-
 @router.get("/preview/{entity_type}/{entity_id}")
 async def preview_export(entity_type: str, entity_id: str):
     """Preview the Obsidian-formatted markdown without writing to vault."""
@@ -736,7 +709,6 @@ async def preview_export(entity_type: str, entity_id: str):
         "link_count": link_count,
         "markdown": markdown,
     }
-
 
 @router.post("/export/{entity_type}/{entity_id}")
 async def export_entity(entity_type: str, entity_id: str):
@@ -758,10 +730,8 @@ async def export_entity(entity_type: str, entity_id: str):
         **result,
     }
 
-
 class BulkExportRequest(BaseModel):
     entity_types: Optional[List[str]] = None  # None means all types
-
 
 @router.post("/export-all")
 async def export_all(req: BulkExportRequest = None):
@@ -815,14 +785,12 @@ async def export_all(req: BulkExportRequest = None):
         "error_details": errors,
     }
 
-
 class SettingsUpdate(BaseModel):
     vault_path: Optional[str] = None
     auto_export: Optional[bool] = None
     include_images: Optional[bool] = None
     link_style: Optional[str] = None
     folder_per_type: Optional[bool] = None
-
 
 @router.post("/settings")
 async def update_settings(update: SettingsUpdate):
@@ -833,7 +801,6 @@ async def update_settings(update: SettingsUpdate):
     _save_settings(settings)
     return {"success": True, "settings": settings}
 
-
 @router.get("/entities")
 async def list_entities(entity_type: Optional[str] = Query(None)):
     """List all available entities, optionally filtered by type."""
@@ -841,7 +808,6 @@ async def list_entities(entity_type: Optional[str] = Query(None)):
     if entity_type:
         entities = [e for e in entities if e["type"] == entity_type]
     return {"entities": entities, "total": len(entities)}
-
 
 @router.get("/graph-data")
 async def graph_data():

--- a/plugins/pdf-exporter/backend/routes.py
+++ b/plugins/pdf-exporter/backend/routes.py
@@ -13,14 +13,13 @@ Routes (mounted at /api/ext/pdf-exporter/...):
   POST /batch                             — batch export multiple entities
 """
 
-import json
 import logging
-import os
+
 import re
-import time
+
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query
@@ -78,7 +77,6 @@ NAME_FIELD_MAP = {
     "campaign": "campaign_name",
     "assembly": "assembly_name",
 }
-
 
 # ─── Template definitions ─────────────────────────────────────────────
 
@@ -146,7 +144,6 @@ TEMPLATES = {
     },
 }
 
-
 # ─── Request models ───────────────────────────────────────────────────
 
 class BatchExportRequest(BaseModel):
@@ -154,7 +151,6 @@ class BatchExportRequest(BaseModel):
     entity_ids: List[str]
     template: str = "entity-summary"
     include_toc: bool = True
-
 
 # ─── Helper functions ─────────────────────────────────────────────────
 
@@ -173,7 +169,6 @@ def get_plugin_settings() -> Dict[str, Any]:
     }
     defaults.update(get_all_settings("pdf-exporter"))
     return defaults
-
 
 def load_entity(entity_type: str, entity_id: str) -> Optional[Dict[str, Any]]:
     """Load an entity's YAML frontmatter and markdown body from disk."""
@@ -211,7 +206,6 @@ def load_entity(entity_type: str, entity_id: str) -> Optional[Dict[str, Any]]:
         "markdown": markdown_body,
     }
 
-
 def get_entity_name(entity_type: str, frontmatter: Dict[str, Any], entity_id: str) -> str:
     """Extract display name from frontmatter, falling back to a formatted ID."""
     name_field = NAME_FIELD_MAP.get(entity_type, "name")
@@ -222,7 +216,6 @@ def get_entity_name(entity_type: str, frontmatter: Dict[str, Any], entity_id: st
         # Convert entity_id to title case
         name = entity_id.replace("_", " ").replace("-", " ").title()
     return str(name)
-
 
 def get_entity_image_path(entity_type: str, entity_id: str, frontmatter: Dict[str, Any]) -> Optional[str]:
     """Get the primary image URL for an entity."""
@@ -237,7 +230,6 @@ def get_entity_image_path(entity_type: str, entity_id: str, frontmatter: Dict[st
         return f"http://localhost:8201/api/files/{folder}/{entity_id}/images/{images[0]}"
 
     return None
-
 
 def list_entities_of_type(entity_type: str) -> List[Dict[str, str]]:
     """List all entity IDs and names for a given type."""
@@ -263,7 +255,6 @@ def list_entities_of_type(entity_type: str) -> List[Dict[str, str]]:
             entities.append({"id": child.name, "name": name})
 
     return entities
-
 
 def format_value(value: Any, indent: int = 0) -> str:
     """Format a YAML value for display in HTML."""
@@ -296,7 +287,6 @@ def format_value(value: Any, indent: int = 0) -> str:
                 parts.append(f"<strong>{k}:</strong> {format_value(v)}")
         return "<br>".join(parts) if parts else '<span class="null-value">--</span>'
     return str(value)
-
 
 # ─── CSS Generation ───────────────────────────────────────────────────
 
@@ -722,7 +712,6 @@ def generate_print_css(settings: Dict[str, Any]) -> str:
     {custom_css}
     """
 
-
 # ─── HTML Renderers ───────────────────────────────────────────────────
 
 def render_character_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
@@ -900,7 +889,6 @@ def render_character_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> st
     {body_html}
     """
 
-
 def render_location_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
     """Render a location guide HTML."""
     fm = data["frontmatter"]
@@ -982,7 +970,6 @@ def render_location_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str
     {body_html}
     """
 
-
 def render_faction_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
     """Render a faction dossier HTML."""
     fm = data["frontmatter"]
@@ -1062,7 +1049,6 @@ def render_faction_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
     {body_html}
     """
 
-
 def render_generic_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
     """Render a generic entity summary HTML."""
     fm = data["frontmatter"]
@@ -1111,7 +1097,6 @@ def render_generic_sheet(data: Dict[str, Any], settings: Dict[str, Any]) -> str:
     {body_html}
     """
 
-
 def render_markdown_simple(text: str) -> str:
     """Simple markdown-to-HTML conversion for body text."""
     try:
@@ -1130,7 +1115,6 @@ def render_markdown_simple(text: str) -> str:
         html = f"<p>{html}</p>"
         return html
 
-
 TEMPLATE_RENDERERS = {
     "character-sheet": render_character_sheet,
     "location-guide": render_location_sheet,
@@ -1138,7 +1122,6 @@ TEMPLATE_RENDERERS = {
     "item-catalog": render_generic_sheet,
     "entity-summary": render_generic_sheet,
 }
-
 
 def select_template(entity_type: str, requested: Optional[str] = None) -> str:
     """Select the best template for an entity type."""
@@ -1152,7 +1135,6 @@ def select_template(entity_type: str, requested: Optional[str] = None) -> str:
         "item": "item-catalog",
     }
     return type_defaults.get(entity_type, "entity-summary")
-
 
 def wrap_full_html(title: str, body: str, settings: Dict[str, Any],
                    show_toolbar: bool = True) -> str:
@@ -1193,7 +1175,6 @@ def wrap_full_html(title: str, body: str, settings: Dict[str, Any],
 </body>
 </html>"""
 
-
 def render_entity_header(entity_type: str, entity_id: str, name: str,
                          settings: Dict[str, Any]) -> str:
     """Render the standard export header for a single entity."""
@@ -1216,7 +1197,6 @@ def render_entity_header(entity_type: str, entity_id: str, name: str,
         </div>
     </div>"""
 
-
 # ─── API Endpoints ────────────────────────────────────────────────────
 
 @router.get("/")
@@ -1231,12 +1211,10 @@ async def plugin_status():
         "entity_types": list(FOLDER_NAME_MAP.keys()),
     }
 
-
 @router.get("/templates")
 async def list_templates():
     """List all available export templates."""
     return {"templates": list(TEMPLATES.values())}
-
 
 @router.get("/entities/{entity_type}")
 async def list_entities(entity_type: str):
@@ -1245,7 +1223,6 @@ async def list_entities(entity_type: str):
         raise HTTPException(status_code=400, detail=f"Unknown entity type: {entity_type}")
     entities = list_entities_of_type(entity_type)
     return {"entity_type": entity_type, "count": len(entities), "entities": entities}
-
 
 @router.get("/preview/{entity_type}/{entity_id}")
 async def preview_entity(
@@ -1271,7 +1248,6 @@ async def preview_entity(
 
     return {"html": header + body, "name": name, "template": template_id}
 
-
 @router.get("/export/{entity_type}/{entity_id}")
 async def export_entity(
     entity_type: str,
@@ -1296,7 +1272,6 @@ async def export_entity(
 
     full_html = wrap_full_html(name, header + content, settings)
     return HTMLResponse(content=full_html)
-
 
 @router.post("/batch")
 async def batch_export(req: BatchExportRequest):
@@ -1365,7 +1340,6 @@ async def batch_export(req: BatchExportRequest):
     title = f"{req.entity_type.title()}s Collection"
     full_html = wrap_full_html(title, "\n".join(body_parts), settings)
     return HTMLResponse(content=full_html)
-
 
 @router.post("/world-bible")
 async def export_world_bible():

--- a/plugins/prompt-engine/backend/routes.py
+++ b/plugins/prompt-engine/backend/routes.py
@@ -27,7 +27,7 @@ import re
 import time
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger("plugin.prompt-engine")
@@ -60,7 +60,6 @@ _RESOLVER_CACHE: dict[str, tuple[Any, float]] = {}  # key -> (value, expires_at;
 # Request / response models
 # ---------------------------------------------------------------------------
 
-
 class VariableToken(BaseModel):
     token: str
     form: str          # "local" | "implicit" | "explicit"
@@ -68,11 +67,9 @@ class VariableToken(BaseModel):
     entity_id: Optional[str] = None
     field_path: str
 
-
 class ParseResponse(BaseModel):
     tokens: list[VariableToken]
     errors: list[str]
-
 
 class ResolveRequest(BaseModel):
     template_text: str = Field(..., description="Raw prompt text containing $variable tokens")
@@ -90,12 +87,10 @@ class ResolveRequest(BaseModel):
     cache_ttl: int = Field(300, description="Cache TTL in seconds (0 = disabled)")
     max_value_length: int = Field(1000, description="Max chars per resolved value")
 
-
 class ResolvedVariable(BaseModel):
     token: str
     resolved_value: Optional[str]
     error: Optional[str] = None
-
 
 class ResolveResponse(BaseModel):
     resolved_text: str
@@ -103,11 +98,9 @@ class ResolveResponse(BaseModel):
     resolution_time_ms: float
     errors: list[str]
 
-
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
-
 
 def _parse_tokens(template_text: str) -> tuple[list[VariableToken], list[str]]:
     """Extract and validate all $variable tokens from template_text."""
@@ -157,11 +150,9 @@ def _parse_tokens(template_text: str) -> tuple[list[VariableToken], list[str]]:
 
     return tokens, errors
 
-
 # ---------------------------------------------------------------------------
 # Resolution helpers
 # ---------------------------------------------------------------------------
-
 
 def _cache_get(key: str) -> Optional[Any]:
     entry = _RESOLVER_CACHE.get(key)
@@ -175,12 +166,10 @@ def _cache_get(key: str) -> Optional[Any]:
         return None
     return value
 
-
 def _cache_set(key: str, value: Any, ttl: int) -> None:
     if ttl <= 0:
         return
     _RESOLVER_CACHE[key] = (value, time.monotonic() + ttl)
-
 
 def _resolve_dot_path(data: dict, path: str) -> tuple[Any, Optional[str]]:
     """Walk *data* along dot-separated *path*. Return (value, error)."""
@@ -194,7 +183,6 @@ def _resolve_dot_path(data: dict, path: str) -> tuple[Any, Optional[str]]:
         current = current[part]
     return current, None
 
-
 def _serialise_value(value: Any) -> str:
     """Serialise any Python value to a string for substitution."""
     if value is None:
@@ -203,14 +191,12 @@ def _serialise_value(value: Any) -> str:
         return ", ".join(str(v) for v in value)
     return str(value)
 
-
 def _sanitise(value: str, max_len: int) -> str:
     """HTML-escape and truncate resolved value (pe_030)."""
     escaped = html.escape(value, quote=False)
     if len(escaped) > max_len:
         escaped = escaped[:max_len]
     return escaped
-
 
 async def _fetch_entity(
     request: Request,
@@ -249,22 +235,18 @@ async def _fetch_entity(
         logger.exception("Entity fetch error for %s:%s", entity_type, entity_id)
         return None, f"Entity fetch error: {exc}"
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
-
 
 @router.get("/")
 async def root():
     """Plugin health check."""
     return {"plugin": "prompt-engine", "version": "1.0.0", "status": "ok"}
 
-
 @router.get("/status")
 async def status():
     return {"status": "ok", "plugin": "prompt-engine", "cache_entries": len(_RESOLVER_CACHE)}
-
 
 @router.post("/parse", response_model=ParseResponse)
 async def parse_template(body: dict):
@@ -278,7 +260,6 @@ async def parse_template(body: dict):
 
     tokens, errors = _parse_tokens(template_text)
     return ParseResponse(tokens=tokens, errors=errors)
-
 
 @router.post("/resolve", response_model=ResolveResponse)
 async def resolve_template(req: ResolveRequest, request: Request):
@@ -433,7 +414,6 @@ async def resolve_template(req: ResolveRequest, request: Request):
         resolution_time_ms=resolution_time_ms,
         errors=all_errors,
     )
-
 
 @router.post("/cache/invalidate")
 async def invalidate_cache(body: dict):

--- a/plugins/showrunner-exporter/backend/routes.py
+++ b/plugins/showrunner-exporter/backend/routes.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.showrunner-exporter")
@@ -45,7 +45,6 @@ TYPE_PREFIX_MAP = {
 
 DEFAULT_ENTITY_TYPES = ["character", "location", "item", "faction", "brand", "district", "job"]
 
-
 # ---------------------------------------------------------------------------
 # Settings helpers
 # ---------------------------------------------------------------------------
@@ -53,18 +52,14 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("showrunner-exporter").get(key, default)
 
-
 def _get_api_key() -> Optional[str]:
     return _get_setting("showrunner_api_key") or None
-
 
 def _get_project_id() -> Optional[str]:
     return _get_setting("project_id") or None
 
-
 def _get_api_url() -> str:
     return _get_setting("showrunner_api_url", "https://api.showrunner.xyz")
-
 
 # ---------------------------------------------------------------------------
 # Export log persistence
@@ -77,26 +72,22 @@ def _load_export_log() -> list:
         pass
     return []
 
-
 def _save_export_log(log: list):
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     EXPORT_LOG_FILE.write_text(
         json.dumps(log[-500:], indent=2, default=str), encoding="utf-8"
     )
 
-
 def _append_export_log(entry: dict):
     log = _load_export_log()
     log.append(entry)
     _save_export_log(log)
-
 
 # ---------------------------------------------------------------------------
 # Entity data helpers
 # ---------------------------------------------------------------------------
 def _get_type_dir(entity_type: str) -> str:
     return entity_type.capitalize() + "s"
-
 
 def _parse_frontmatter(filepath: str) -> dict:
     """Read a markdown file and extract YAML frontmatter as a dict."""
@@ -122,7 +113,6 @@ def _parse_frontmatter(filepath: str) -> dict:
                 data[key.strip()] = val
         return data
 
-
 def _extract_markdown_body(filepath: str) -> str:
     """Extract the markdown body after frontmatter."""
     try:
@@ -135,7 +125,6 @@ def _extract_markdown_body(filepath: str) -> str:
     if match:
         return match.group(1).strip()
     return content.strip()
-
 
 def _extract_dialogue_samples(markdown_body: str, limit: int = 5) -> list[str]:
     """Extract dialogue lines from markdown body (lines in quotes or after character names)."""
@@ -157,7 +146,6 @@ def _extract_dialogue_samples(markdown_body: str, limit: int = 5) -> list[str]:
             break
     return samples
 
-
 async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
     """Fetch entity data from the backend API."""
     async with httpx.AsyncClient(timeout=10) as client:
@@ -168,7 +156,6 @@ async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
                 detail=f"Failed to fetch entity {entity_type}/{entity_id}",
             )
         return resp.json()
-
 
 def _scan_entities(entity_type: str) -> list[dict]:
     """Scan all entities of a given type from the filesystem."""
@@ -226,7 +213,6 @@ def _scan_entities(entity_type: str) -> list[dict]:
 
     return results
 
-
 # ---------------------------------------------------------------------------
 # Showrunner format converters
 # ---------------------------------------------------------------------------
@@ -279,7 +265,6 @@ def character_to_showrunner(entity_data: dict, include_voice: bool = True) -> di
 
     return result
 
-
 def location_to_showrunner(entity_data: dict) -> dict:
     """Convert location entity to Showrunner scene/set format."""
     return {
@@ -300,7 +285,6 @@ def location_to_showrunner(entity_data: dict) -> dict:
         },
     }
 
-
 def faction_to_showrunner(entity_data: dict) -> dict:
     """Convert faction entity to Showrunner organization format."""
     return {
@@ -318,7 +302,6 @@ def faction_to_showrunner(entity_data: dict) -> dict:
             "exported_at": datetime.now(timezone.utc).isoformat(),
         },
     }
-
 
 def entity_to_showrunner(entity_data: dict, entity_type: str) -> dict:
     """Route entity to appropriate Showrunner converter."""
@@ -344,7 +327,6 @@ def entity_to_showrunner(entity_data: dict, entity_type: str) -> dict:
                 "exported_at": datetime.now(timezone.utc).isoformat(),
             },
         }
-
 
 def _build_episode_outline(title: str, characters: list, scenes: list) -> dict:
     """Build a Showrunner episode outline from structured data."""
@@ -372,7 +354,6 @@ def _build_episode_outline(title: str, characters: list, scenes: list) -> dict:
         },
     }
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -381,10 +362,8 @@ class ExportEpisodeRequest(BaseModel):
     characters: list = []
     scenes: list = []
 
-
 class BatchExportRequest(BaseModel):
     entity_types: list[str] = ["character"]
-
 
 # ---------------------------------------------------------------------------
 # Mock Showrunner projects (used when no API key is configured)
@@ -409,7 +388,6 @@ MOCK_PROJECTS = [
         "created_at": "2025-12-01T14:00:00Z",
     },
 ]
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -440,7 +418,6 @@ async def status():
         "successful_exports": successful,
         "last_export": last_export,
     }
-
 
 @router.post("/export/character/{entity_id}")
 async def export_character(entity_id: str):
@@ -509,7 +486,6 @@ async def export_character(entity_id: str):
         ),
     }
 
-
 @router.post("/export/episode")
 async def export_episode(req: ExportEpisodeRequest):
     """Export an episode outline to Showrunner format."""
@@ -560,7 +536,6 @@ async def export_episode(req: ExportEpisodeRequest):
         "message": f"Episode '{req.title}' exported with {len(req.scenes)} scenes",
     }
 
-
 @router.get("/preview/{entity_type}/{entity_id}")
 async def preview_export(entity_type: str, entity_id: str):
     """Preview the Showrunner-formatted JSON for an entity without exporting."""
@@ -584,7 +559,6 @@ async def preview_export(entity_type: str, entity_id: str):
         "fields_populated": sum(1 for v in showrunner_data.values() if v),
         "fields_total": len(showrunner_data),
     }
-
 
 @router.post("/batch-export")
 async def batch_export(req: BatchExportRequest):
@@ -637,7 +611,6 @@ async def batch_export(req: BatchExportRequest):
         "message": f"Exported {len(results)} entities with {len(errors)} errors",
     }
 
-
 @router.get("/projects")
 async def list_projects():
     """List Showrunner projects. Returns mock data if no API key is configured."""
@@ -675,7 +648,6 @@ async def list_projects():
             "projects": MOCK_PROJECTS,
         }
 
-
 @router.get("/export-log")
 async def get_export_log(limit: int = 50):
     """Get export history."""
@@ -685,7 +657,6 @@ async def get_export_log(limit: int = 50):
         "total": len(log),
         "items": log[:limit],
     }
-
 
 @router.get("/export-status/{entity_type}/{entity_id}")
 async def get_export_status(entity_type: str, entity_id: str):
@@ -711,7 +682,6 @@ async def get_export_status(entity_type: str, entity_id: str):
         "project_id": _get_project_id() or "",
         "api_configured": bool(_get_api_key()),
     }
-
 
 @router.get("/characters")
 async def list_characters():
@@ -743,7 +713,6 @@ async def list_characters():
         "total": len(characters),
         "exported_count": sum(1 for c in characters if c.get("export_count", 0) > 0),
     }
-
 
 @router.get("/stats")
 async def get_stats():

--- a/plugins/social-publisher/backend/routes.py
+++ b/plugins/social-publisher/backend/routes.py
@@ -12,14 +12,14 @@ render previews.
 
 import json
 import logging
-import os
+
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 logger = logging.getLogger("plugin.social-publisher")
@@ -116,7 +116,6 @@ DEFAULT_TEMPLATES = [
     },
 ]
 
-
 # ---------------------------------------------------------------------------
 # Data helpers
 # ---------------------------------------------------------------------------
@@ -132,7 +131,6 @@ def _ensure_data_dir():
             json.dumps(DEFAULT_TEMPLATES, indent=2), encoding="utf-8"
         )
 
-
 def _load_json(path: Path) -> list[dict]:
     _ensure_data_dir()
     try:
@@ -140,33 +138,26 @@ def _load_json(path: Path) -> list[dict]:
     except Exception:
         return []
 
-
 def _save_json(path: Path, data: list[dict]):
     _ensure_data_dir()
     path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
 
-
 def _load_history() -> list[dict]:
     return _load_json(HISTORY_FILE)
 
-
 def _save_history(history: list[dict]):
     _save_json(HISTORY_FILE, history)
-
 
 def _append_history(entry: dict):
     history = _load_history()
     history.insert(0, entry)
     _save_history(history[:1000])
 
-
 def _load_scheduled() -> list[dict]:
     return _load_json(SCHEDULED_FILE)
 
-
 def _save_scheduled(items: list[dict]):
     _save_json(SCHEDULED_FILE, items)
-
 
 def _load_templates() -> list[dict]:
     templates = _load_json(TEMPLATES_FILE)
@@ -175,14 +166,12 @@ def _load_templates() -> list[dict]:
         return DEFAULT_TEMPLATES
     return templates
 
-
 # ---------------------------------------------------------------------------
 # Settings helpers
 # ---------------------------------------------------------------------------
 def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("social-publisher").get(key, default)
-
 
 def _platform_configured(platform: str) -> bool:
     """Check whether the required API keys exist for a platform."""
@@ -211,7 +200,6 @@ def _platform_configured(platform: str) -> bool:
         )
     return False
 
-
 # ---------------------------------------------------------------------------
 # Entity helpers
 # ---------------------------------------------------------------------------
@@ -228,7 +216,6 @@ async def _fetch_entity(entity_type: str, entity_id: str) -> dict:
             )
         return resp.json()
 
-
 def _get_entity_image_url(entity: dict, entity_type: str, entity_id: str) -> str | None:
     """Resolve the primary image URL for an entity."""
     image_file = (
@@ -244,7 +231,6 @@ def _get_entity_image_url(entity: dict, entity_type: str, entity_id: str) -> str
         else entity_type
     )
     return f"{BACKEND_URL}/files/{type_plural}/{entity_id}/assets/{image_file}"
-
 
 def _render_template(
     template_str: str, entity: dict, hashtags: str = ""
@@ -275,7 +261,6 @@ def _render_template(
     while "\n\n\n" in text:
         text = text.replace("\n\n\n", "\n\n")
     return text.strip()
-
 
 # ---------------------------------------------------------------------------
 # Platform publishers (mock when not configured)
@@ -340,7 +325,6 @@ async def _publish_twitter(text: str, image_url: str | None = None) -> dict:
             "error": str(exc),
         }
 
-
 async def _publish_bluesky(text: str, image_url: str | None = None) -> dict:
     """Publish to Bluesky.  Returns mock when credentials missing."""
     if not _platform_configured("bluesky"):
@@ -387,7 +371,6 @@ async def _publish_bluesky(text: str, image_url: str | None = None) -> dict:
             "platform": "bluesky",
             "error": str(exc),
         }
-
 
 async def _publish_instagram(text: str, image_url: str | None = None) -> dict:
     """Publish to Instagram via Graph API.  Returns mock when not configured."""
@@ -445,7 +428,6 @@ async def _publish_instagram(text: str, image_url: str | None = None) -> dict:
             "error": str(exc),
         }
 
-
 async def _publish_threads(text: str, image_url: str | None = None) -> dict:
     """Publish to Threads via API.  Returns mock when not configured."""
     if not _platform_configured("threads"):
@@ -501,14 +483,12 @@ async def _publish_threads(text: str, image_url: str | None = None) -> dict:
             "error": str(exc),
         }
 
-
 PUBLISHER_MAP = {
     "twitter": _publish_twitter,
     "bluesky": _publish_bluesky,
     "instagram": _publish_instagram,
     "threads": _publish_threads,
 }
-
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -521,7 +501,6 @@ class PublishRequest(BaseModel):
     entity_id: Optional[str] = None
     template_id: Optional[str] = None
     schedule_at: Optional[str] = None  # ISO-8601 datetime string
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -556,7 +535,6 @@ async def status():
         ),
         "auto_include_image": settings.get("auto_include_image", True),
     }
-
 
 @router.post("/publish")
 async def publish(req: PublishRequest):
@@ -648,13 +626,11 @@ async def publish(req: PublishRequest):
         + (" (some mocked)" if any(r.get("mock") for r in results) else ""),
     }
 
-
 @router.get("/templates")
 async def list_templates():
     """Return all available post templates."""
     templates = _load_templates()
     return {"templates": templates}
-
 
 @router.get("/templates/preview")
 async def preview_template(
@@ -689,7 +665,6 @@ async def preview_template(
         },
     }
 
-
 @router.get("/history")
 async def get_history(
     entity_type: str | None = None,
@@ -715,7 +690,6 @@ async def get_history(
 
     return {"total": len(history), "items": history[:limit]}
 
-
 @router.get("/scheduled")
 async def get_scheduled():
     """Return all upcoming scheduled posts."""
@@ -725,7 +699,6 @@ async def get_scheduled():
     # Sort by schedule_at ascending
     pending.sort(key=lambda s: s.get("schedule_at", ""))
     return {"total": len(pending), "items": pending}
-
 
 @router.delete("/scheduled/{post_id}")
 async def cancel_scheduled(post_id: str):
@@ -753,7 +726,6 @@ async def cancel_scheduled(post_id: str):
         raise HTTPException(status_code=404, detail=f"Scheduled post '{post_id}' not found.")
 
     return {"success": True, "message": "Scheduled post cancelled."}
-
 
 @router.get("/stats")
 async def get_stats():

--- a/plugins/uefn-exporter/backend/routes.py
+++ b/plugins/uefn-exporter/backend/routes.py
@@ -7,7 +7,6 @@ and Creative island metadata from City of Brains Studio entities.
 All routes are mounted at /api/ext/uefn-exporter/ by the plugin loader.
 """
 
-import json
 import logging
 import os
 import re
@@ -84,7 +83,6 @@ VERSE_DEFAULTS = {
     "[]string": "array{}",
 }
 
-
 # ─── Helpers ──────────────────────────────────────────────────────────
 
 def _get_setting(key: str, default: Any = None) -> Any:
@@ -92,14 +90,11 @@ def _get_setting(key: str, default: Any = None) -> Any:
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("uefn-exporter").get(key, default)
 
-
 def _verse_module() -> str:
     return _get_setting("verse_module", "CityOfBrains")
 
-
 def _creative_version() -> str:
     return _get_setting("creative_version", "31.00")
-
 
 def _sanitize_verse_id(name: str) -> str:
     """Convert a name to a valid Verse identifier (snake_case, alphanumeric)."""
@@ -108,7 +103,6 @@ def _sanitize_verse_id(name: str) -> str:
     if sanitized and sanitized[0].isdigit():
         sanitized = "_" + sanitized
     return sanitized or "unnamed"
-
 
 def _parse_frontmatter(content: str) -> Dict[str, Any]:
     """Parse YAML frontmatter from markdown content."""
@@ -178,7 +172,6 @@ def _parse_frontmatter(content: str) -> Dict[str, Any]:
 
     return fields
 
-
 def _read_entity(entity_type: str, entity_id: str) -> Optional[Dict[str, Any]]:
     """Read an entity's markdown file and parse its frontmatter fields."""
     dir_name = ENTITY_TYPE_DIRS.get(entity_type)
@@ -206,7 +199,6 @@ def _read_entity(entity_type: str, entity_id: str) -> Optional[Dict[str, Any]]:
     fields["_entity_id"] = entity_id
     fields["_source_file"] = str(md_file)
     return fields
-
 
 def _read_template_fields(entity_type: str) -> Dict[str, str]:
     """Read a template and extract field names with their inferred types."""
@@ -241,7 +233,6 @@ def _read_template_fields(entity_type: str) -> Dict[str, str]:
 
     return type_map
 
-
 def _infer_verse_type(value: Any) -> str:
     """Infer a Verse type from a Python value."""
     if isinstance(value, bool):
@@ -253,7 +244,6 @@ def _infer_verse_type(value: Any) -> str:
     elif isinstance(value, list):
         return "[]string"
     return "string"
-
 
 def _verse_value(value: Any, vtype: str) -> str:
     """Convert a Python value to its Verse literal representation."""
@@ -280,11 +270,9 @@ def _verse_value(value: Any, vtype: str) -> str:
     else:
         return f'"{_escape_verse_string(str(value))}"'
 
-
 def _escape_verse_string(s: str) -> str:
     """Escape special characters for Verse string literals."""
     return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
-
 
 def _list_entities(entity_type: str) -> List[str]:
     """List all entity IDs of a given type."""
@@ -296,7 +284,6 @@ def _list_entities(entity_type: str) -> List[str]:
         return []
     return [d.name for d in sorted(entity_root.iterdir())
             if d.is_dir() and not d.name.startswith(".")]
-
 
 # ─── Verse Code Generators ───────────────────────────────────────────
 
@@ -347,7 +334,6 @@ def _generate_verse_class(entity_type: str) -> str:
 
     return "\n".join(lines)
 
-
 def _generate_verse_instance(entity_type: str, entity_id: str) -> str:
     """Generate a Verse data instance for a specific entity."""
     entity = _read_entity(entity_type, entity_id)
@@ -381,7 +367,6 @@ def _generate_verse_instance(entity_type: str, entity_id: str) -> str:
         lines.append(f"    {safe_key} = {vval}")
 
     return "\n".join(lines)
-
 
 def _generate_device_config(entity_type: str, entity_id: str) -> str:
     """Generate a UEFN device configuration block for an entity."""
@@ -471,7 +456,6 @@ def _generate_device_config(entity_type: str, entity_id: str) -> str:
 
     return "\n".join(lines)
 
-
 def _generate_dialogue_verse(entity_id: str) -> str:
     """Generate Verse dialogue structures for a character's dialogue data."""
     # Try to find dialogues referencing this character
@@ -554,7 +538,6 @@ def _generate_dialogue_verse(entity_id: str) -> str:
 
     return "\n".join(lines)
 
-
 def _generate_island_metadata(entities: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Generate Creative island metadata from a collection of entities."""
     characters = [e for e in entities if e.get("_entity_type") == "character"]
@@ -620,7 +603,6 @@ def _generate_island_metadata(entities: List[Dict[str, Any]]) -> Dict[str, Any]:
         },
     }
 
-
 # ─── Request Models ──────────────────────────────────────────────────
 
 class BatchExportRequest(BaseModel):
@@ -632,7 +614,6 @@ class BatchExportRequest(BaseModel):
     include_devices: bool = True
     include_dialogue: bool = False
 
-
 class ExportResult(BaseModel):
     """Single export result."""
     entity_type: str
@@ -640,7 +621,6 @@ class ExportResult(BaseModel):
     verse_code: str
     device_code: Optional[str] = None
     dialogue_code: Optional[str] = None
-
 
 # ─── API Routes ───────────────────────────────────────────────────────
 
@@ -666,7 +646,6 @@ async def plugin_status():
         "entity_counts": entity_counts,
     }
 
-
 @router.get("/entity-types")
 async def list_entity_types():
     """List all available entity types and their entity counts."""
@@ -681,7 +660,6 @@ async def list_entity_types():
         })
     return {"entity_types": result}
 
-
 @router.get("/entities/{entity_type}")
 async def list_entities_of_type(entity_type: str):
     """List all entities of a specific type."""
@@ -695,7 +673,6 @@ async def list_entities_of_type(entity_type: str):
         "entity_ids": entities,
     }
 
-
 @router.get("/verse/{entity_type}", response_class=PlainTextResponse)
 async def generate_verse_class(entity_type: str):
     """Generate a Verse class definition for an entity type."""
@@ -704,7 +681,6 @@ async def generate_verse_class(entity_type: str):
                             detail=f"Unknown entity type: {entity_type}")
     code = _generate_verse_class(entity_type)
     return PlainTextResponse(content=code, media_type="text/plain")
-
 
 @router.get("/preview/{entity_type}/{entity_id}", response_class=PlainTextResponse)
 async def preview_verse_instance(entity_type: str, entity_id: str):
@@ -715,7 +691,6 @@ async def preview_verse_instance(entity_type: str, entity_id: str):
     code = _generate_verse_instance(entity_type, entity_id)
     return PlainTextResponse(content=code, media_type="text/plain")
 
-
 @router.get("/preview-device/{entity_type}/{entity_id}", response_class=PlainTextResponse)
 async def preview_device_config(entity_type: str, entity_id: str):
     """Preview a UEFN device configuration for an entity."""
@@ -724,7 +699,6 @@ async def preview_device_config(entity_type: str, entity_id: str):
                             detail=f"Unknown entity type: {entity_type}")
     code = _generate_device_config(entity_type, entity_id)
     return PlainTextResponse(content=code, media_type="text/plain")
-
 
 @router.post("/export/{entity_type}/{entity_id}")
 async def export_entity(entity_type: str, entity_id: str,
@@ -789,7 +763,6 @@ async def export_entity(entity_type: str, entity_id: str,
         "files_written": files_written,
         "exported_at": datetime.utcnow().isoformat() + "Z",
     }
-
 
 @router.post("/batch-export")
 async def batch_export(req: BatchExportRequest):
@@ -895,13 +868,11 @@ async def batch_export(req: BatchExportRequest):
         "exported_at": datetime.utcnow().isoformat() + "Z",
     }
 
-
 @router.get("/dialogue/{entity_id}", response_class=PlainTextResponse)
 async def export_dialogue(entity_id: str):
     """Export dialogue data for a character in UEFN-compatible Verse format."""
     code = _generate_dialogue_verse(entity_id)
     return PlainTextResponse(content=code, media_type="text/plain")
-
 
 @router.get("/island-metadata")
 async def get_island_metadata(
@@ -921,7 +892,6 @@ async def get_island_metadata(
                 all_entities.append(e)
 
     return _generate_island_metadata(all_entities)
-
 
 @router.get("/island-metadata/verse", response_class=PlainTextResponse)
 async def get_island_metadata_verse(

--- a/plugins/unity-exporter/backend/routes.py
+++ b/plugins/unity-exporter/backend/routes.py
@@ -13,7 +13,7 @@ import json
 import logging
 import re
 import shutil
-import uuid
+
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -122,7 +122,6 @@ CSHARP_TYPE_MAP = {
     "connections": "List<string>",
 }
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -136,7 +135,6 @@ class GenerateScriptsRequest(BaseModel):
     entity_types: Optional[List[str]] = None
     output_path: Optional[str] = None
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -146,7 +144,6 @@ def _get_settings() -> dict:
     from services.plugin_settings_service import get_all_settings
     return {**DEFAULT_SETTINGS, **get_all_settings("unity-exporter")}
 
-
 def _entity_dir(entity_type: str, entity_id: str) -> Path:
     """Return the directory containing an entity's files."""
     mapping = ENTITY_MAP.get(entity_type)
@@ -155,7 +152,6 @@ def _entity_dir(entity_type: str, entity_id: str) -> Path:
     folder, _prefix = mapping
     return BRAINS_ROOT / folder / entity_id
 
-
 def _entity_file(entity_type: str, entity_id: str) -> Path:
     """Resolve the canonical markdown file for an entity."""
     mapping = ENTITY_MAP.get(entity_type)
@@ -163,7 +159,6 @@ def _entity_file(entity_type: str, entity_id: str) -> Path:
         raise HTTPException(status_code=400, detail=f"Unknown entity type: {entity_type}")
     folder, prefix = mapping
     return BRAINS_ROOT / folder / entity_id / f"{prefix}{entity_id}.md"
-
 
 def _parse_entity_markdown(filepath: Path) -> Dict[str, Any]:
     """Parse a Studio entity markdown file.
@@ -194,7 +189,6 @@ def _parse_entity_markdown(filepath: Path) -> Dict[str, Any]:
         "raw": text,
     }
 
-
 def _find_portrait(entity_type: str, entity_id: str) -> Optional[Path]:
     """Find the portrait image for an entity if it exists."""
     entity_dir = _entity_dir(entity_type, entity_id)
@@ -212,13 +206,11 @@ def _find_portrait(entity_type: str, entity_id: str) -> Optional[Path]:
             return images[0]
     return None
 
-
 def _to_pascal_case(s: str) -> str:
     """Convert a string to PascalCase for C# class names."""
     s = re.sub(r'[^a-zA-Z0-9_\s-]', '', s)
     words = re.split(r'[\s_-]+', s)
     return ''.join(w.capitalize() for w in words if w)
-
 
 def _to_camel_case(s: str) -> str:
     """Convert a string to camelCase for C# field names."""
@@ -226,7 +218,6 @@ def _to_camel_case(s: str) -> str:
     if not pascal:
         return "unnamed"
     return pascal[0].lower() + pascal[1:]
-
 
 def _infer_csharp_type(key: str, value: Any) -> str:
     """Infer the C# type for a field based on its key name and value."""
@@ -254,17 +245,14 @@ def _infer_csharp_type(key: str, value: Any) -> str:
 
     return "string"
 
-
 def _stable_guid(seed_string: str) -> str:
     """Generate a stable Unity-compatible GUID from a seed string."""
     return hashlib.md5(seed_string.encode("utf-8")).hexdigest()
-
 
 def _stable_file_id(seed_string: str) -> int:
     """Generate a stable Unity fileID from a seed string."""
     h = hashlib.sha256(seed_string.encode("utf-8")).digest()
     return int.from_bytes(h[:4], "big") % 2147483647
-
 
 def _format_csharp_value(value: Any, csharp_type: str) -> str:
     """Format a Python value as a C# literal for ScriptableObject YAML."""
@@ -299,7 +287,6 @@ def _format_csharp_value(value: Any, csharp_type: str) -> str:
         return "{fileID: 0}"
     else:
         return str(value) if value else ""
-
 
 # ---------------------------------------------------------------------------
 # C# Code Generation
@@ -386,7 +373,6 @@ def _generate_csharp_class(entity_type: str, fields: Dict[str, Any], settings: d
 
     return "\n".join(lines)
 
-
 def _categorize_field(field_name: str) -> str:
     """Categorize a field name into a Unity Inspector header group."""
     fn = field_name.lower()
@@ -412,7 +398,6 @@ def _categorize_field(field_name: str) -> str:
     if any(w in fn for w in ("skill", "ability", "spell", "power", "talent")):
         return "Abilities"
     return "Properties"
-
 
 def _generate_scriptable_object_yaml(
     entity_type: str,
@@ -482,7 +467,6 @@ def _generate_scriptable_object_yaml(
     lines.append(f"")
     return "\n".join(lines)
 
-
 def _generate_enum_code(entity_type: str, field_name: str, values: List[str], namespace: str) -> str:
     """Generate a C# enum from a list of string values."""
     enum_name = _to_pascal_case(field_name)
@@ -508,7 +492,6 @@ def _generate_enum_code(entity_type: str, field_name: str, values: List[str], na
     lines.append(f"")
 
     return "\n".join(lines)
-
 
 def _collect_all_fields_for_type(entity_type: str) -> Dict[str, Any]:
     """Scan all entities of a type and collect a union of all fields with sample values."""
@@ -540,7 +523,6 @@ def _collect_all_fields_for_type(entity_type: str) -> Dict[str, Any]:
             continue
 
     return all_fields
-
 
 def _list_entities_for_type(entity_type: str) -> List[Dict[str, Any]]:
     """List all entities of a given type with basic info."""
@@ -582,7 +564,6 @@ def _list_entities_for_type(entity_type: str) -> List[Dict[str, Any]]:
 
     return entities
 
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -614,7 +595,6 @@ async def index():
         "total_entities": total_entities,
     }
 
-
 @router.get("/entities/{entity_type}")
 async def list_entities(entity_type: str):
     """List all entities of a given type available for export."""
@@ -627,7 +607,6 @@ async def list_entities(entity_type: str):
         "count": len(entities),
         "entities": entities,
     }
-
 
 @router.get("/preview/{entity_type}/{entity_id}")
 async def preview_scriptable_object(entity_type: str, entity_id: str, format: str = "yaml"):
@@ -660,7 +639,6 @@ async def preview_scriptable_object(entity_type: str, entity_id: str, format: st
         "file_name": f"{entity_id}.asset",
     }
 
-
 @router.get("/csharp/{entity_type}")
 async def generate_csharp_class(entity_type: str):
     """Generate the C# ScriptableObject data class for an entity type.
@@ -688,7 +666,6 @@ async def generate_csharp_class(entity_type: str):
         "csharp_code": csharp_code,
         "namespace": settings.get("namespace", "CityOfBrains.Data"),
     }
-
 
 @router.post("/export/{entity_type}/{entity_id}")
 async def export_entity(entity_type: str, entity_id: str, output_path: Optional[str] = None):
@@ -783,7 +760,6 @@ async def export_entity(entity_type: str, entity_id: str, output_path: Optional[
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
-
 @router.post("/batch-export")
 async def batch_export(req: BatchExportRequest):
     """Export multiple entities of a given type as .asset files."""
@@ -817,7 +793,6 @@ async def batch_export(req: BatchExportRequest):
         "errors": errors,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
-
 
 @router.post("/generate-scripts")
 async def generate_scripts(req: GenerateScriptsRequest):
@@ -935,7 +910,6 @@ async def generate_scripts(req: GenerateScriptsRequest):
         "namespace": settings.get("namespace", "CityOfBrains.Data"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
-
 
 @router.get("/export-history")
 async def get_export_history():

--- a/plugins/voice-forge/backend/routes.py
+++ b/plugins/voice-forge/backend/routes.py
@@ -7,7 +7,7 @@ and audio history tracking for character entities.
 
 import json
 import logging
-import os
+
 import time
 import uuid
 from pathlib import Path
@@ -40,10 +40,8 @@ def _get_setting(key: str, default=None):
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("voice-forge").get(key, default)
 
-
 def _get_api_key() -> Optional[str]:
     return _get_setting("elevenlabs_api_key") or None
-
 
 def _entity_assets_dir(entity_type: str, entity_id: str) -> Path:
     """Return the assets directory for an entity, creating it if needed."""
@@ -53,7 +51,6 @@ def _entity_assets_dir(entity_type: str, entity_id: str) -> Path:
     assets.mkdir(parents=True, exist_ok=True)
     return assets
 
-
 def _load_profiles() -> dict:
     try:
         if PROFILES_FILE.exists():
@@ -62,10 +59,8 @@ def _load_profiles() -> dict:
         pass
     return {}
 
-
 def _save_profiles(profiles: dict):
     PROFILES_FILE.write_text(json.dumps(profiles, indent=2), encoding="utf-8")
-
 
 def _load_generation_log() -> list:
     try:
@@ -75,11 +70,9 @@ def _load_generation_log() -> list:
         pass
     return []
 
-
 def _save_generation_log(log: list):
     # Keep last 500 entries
     GENERATION_LOG.write_text(json.dumps(log[-500:], indent=2), encoding="utf-8")
-
 
 # ---------------------------------------------------------------------------
 # Models
@@ -93,7 +86,6 @@ class GenerateRequest(BaseModel):
     style: Optional[str] = "normal"
     model_id: Optional[str] = None
 
-
 class VoiceProfile(BaseModel):
     entity_id: str
     voice_id: str
@@ -105,7 +97,6 @@ class VoiceProfile(BaseModel):
         "excited": {"stability": 0.25, "similarity_boost": 0.8},
         "sad": {"stability": 0.7, "similarity_boost": 0.7},
     })
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -125,7 +116,6 @@ async def plugin_status():
         "default_voice_id": _get_setting("default_voice_id", "21m00Tcm4TlvDq8ikWAM"),
         "profiles_count": len(_load_profiles()),
     }
-
 
 @router.get("/voices")
 async def list_voices():
@@ -175,7 +165,6 @@ async def list_voices():
     except Exception as exc:
         logger.error("Failed to fetch voices: %s", exc)
         return {"source": "error", "message": str(exc), "voices": []}
-
 
 @router.post("/generate")
 async def generate_speech(req: GenerateRequest):
@@ -293,7 +282,6 @@ async def generate_speech(req: GenerateRequest):
         "voice_id": voice_id,
     }
 
-
 @router.get("/history/{entity_type}/{entity_id}")
 async def get_history(entity_type: str, entity_id: str):
     """List all generated audio files for an entity."""
@@ -317,14 +305,12 @@ async def get_history(entity_type: str, entity_id: str):
     audio_files.sort(key=lambda x: x["created"], reverse=True)
     return {"entity_type": entity_type, "entity_id": entity_id, "files": audio_files}
 
-
 def _parse_style_from_filename(filename: str) -> str:
     """Extract style from filename like voice_angry_1234_abcd.mp3"""
     parts = filename.replace("voice_", "").split("_")
     if parts:
         return parts[0]
     return "normal"
-
 
 @router.delete("/audio/{entity_type}/{entity_id}/{filename}")
 async def delete_audio(entity_type: str, entity_id: str, filename: str):
@@ -343,13 +329,11 @@ async def delete_audio(entity_type: str, entity_id: str, filename: str):
     logger.info("Deleted audio file: %s", filepath)
     return {"success": True, "message": f"Deleted {filename}"}
 
-
 @router.get("/voice-profiles")
 async def list_voice_profiles():
     """List all voice profiles."""
     profiles = _load_profiles()
     return {"profiles": profiles}
-
 
 @router.post("/voice-profiles")
 async def upsert_voice_profile(profile: VoiceProfile):
@@ -364,7 +348,6 @@ async def upsert_voice_profile(profile: VoiceProfile):
     _save_profiles(profiles)
     logger.info("Updated voice profile for entity %s", profile.entity_id)
     return {"success": True, "profile": profiles[profile.entity_id]}
-
 
 @router.get("/generation-log")
 async def get_generation_log():

--- a/plugins/webhook-automations/backend/routes.py
+++ b/plugins/webhook-automations/backend/routes.py
@@ -16,7 +16,6 @@ from datetime import datetime, timezone
 import httpx
 import hmac
 import hashlib
-import asyncio
 
 from services.plugin_data_service import PluginDataService
 
@@ -28,14 +27,12 @@ data_svc = PluginDataService("webhook-automations")
 DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
 RULES_FILE = os.path.join(DATA_DIR, "rules.json")
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 def _ensure_data_dir():
     os.makedirs(DATA_DIR, exist_ok=True)
-
 
 def _load_json(path: str, default=None):
     _ensure_data_dir()
@@ -49,20 +46,16 @@ def _load_json(path: str, default=None):
     except (json.JSONDecodeError, IOError):
         return default
 
-
 def _save_json(path: str, data):
     _ensure_data_dir()
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, default=str)
 
-
 def _load_rules() -> list[dict]:
     return _load_json(RULES_FILE, [])
 
-
 def _save_rules(rules: list[dict]):
     _save_json(RULES_FILE, rules)
-
 
 def _find_rule(rule_id: str) -> tuple[list[dict], dict | None, int]:
     """Return (rules_list, matched_rule, index). Index is -1 if not found."""
@@ -72,14 +65,12 @@ def _find_rule(rule_id: str) -> tuple[list[dict], dict | None, int]:
             return rules, r, i
     return rules, None, -1
 
-
 def _substitute_payload(template: str, variables: dict) -> str:
     """Replace {{key}} placeholders with values from *variables*."""
     result = template
     for key, value in variables.items():
         result = result.replace("{{" + key + "}}", str(value))
     return result
-
 
 def _build_payload(rule: dict, event_data: dict) -> str:
     """Build the webhook payload body, either from a custom template or default."""
@@ -106,11 +97,9 @@ def _build_payload(rule: dict, event_data: dict) -> str:
     }
     return json.dumps(payload, default=str)
 
-
 def _sign_payload(payload: str, secret: str) -> str:
     """Create HMAC-SHA256 signature for the payload."""
     return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
-
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -135,7 +124,6 @@ class RuleCreate(BaseModel):
     )
     active: bool = True
 
-
 class RuleUpdate(BaseModel):
     name: Optional[str] = None
     event_pattern: Optional[str] = None
@@ -145,7 +133,6 @@ class RuleUpdate(BaseModel):
     headers: Optional[dict[str, str]] = None
     payload_template: Optional[str] = None
     active: Optional[bool] = None
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -171,13 +158,11 @@ async def plugin_status():
         "success_rate": round(success_count / total_deliveries * 100, 1) if total_deliveries else 0,
     }
 
-
 @router.get("/rules")
 async def list_rules():
     """List all webhook rules."""
     rules = _load_rules()
     return {"rules": rules, "count": len(rules)}
-
 
 @router.post("/rules")
 async def create_rule(body: RuleCreate):
@@ -201,7 +186,6 @@ async def create_rule(body: RuleCreate):
     logger.info("[webhook-automations] Rule created: %s (%s)", rule["name"], rule["id"])
     return {"rule": rule, "message": "Rule created"}
 
-
 @router.put("/rules/{rule_id}")
 async def update_rule(rule_id: str, body: RuleUpdate):
     """Update an existing webhook rule."""
@@ -220,7 +204,6 @@ async def update_rule(rule_id: str, body: RuleUpdate):
     logger.info("[webhook-automations] Rule updated: %s", rule_id)
     return {"rule": rule, "message": "Rule updated"}
 
-
 @router.delete("/rules/{rule_id}")
 async def delete_rule(rule_id: str):
     """Delete a webhook rule."""
@@ -232,7 +215,6 @@ async def delete_rule(rule_id: str):
     _save_rules(rules)
     logger.info("[webhook-automations] Rule deleted: %s", rule_id)
     return {"message": "Rule deleted", "id": rule_id}
-
 
 @router.post("/rules/{rule_id}/test")
 async def test_rule(rule_id: str):
@@ -304,7 +286,6 @@ async def test_rule(rule_id: str):
     data_svc.create(record_type="delivery_log", data=log_entry, record_id=log_entry["id"])
     return {"result": log_entry, "payload_sent": payload_body}
 
-
 @router.get("/logs")
 async def get_logs(
     rule_id: Optional[str] = Query(None),
@@ -331,7 +312,6 @@ async def get_logs(
     page = logs[offset: offset + limit]
     return {"logs": page, "total": total, "limit": limit, "offset": offset}
 
-
 @router.get("/logs/{rule_id}")
 async def get_rule_logs(
     rule_id: str,
@@ -348,7 +328,6 @@ async def get_rule_logs(
     total = len(logs)
     page = logs[offset: offset + limit]
     return {"logs": page, "total": total, "rule_name": rule["name"], "limit": limit, "offset": offset}
-
 
 @router.post("/migrate-logs")
 async def migrate_legacy_logs():

--- a/plugins/youtube-manager/backend/routes.py
+++ b/plugins/youtube-manager/backend/routes.py
@@ -3,16 +3,13 @@ YouTube Manager Plugin - Backend Routes
 Handles video uploads, metadata management, and YouTube API integration.
 """
 
-from fastapi import APIRouter, HTTPException, UploadFile, File, Form
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Optional, List
 from pathlib import Path
 from datetime import datetime
 import json
 import uuid
-import os
-import shutil
 
 router = APIRouter()
 
@@ -41,13 +38,11 @@ YOUTUBE_CATEGORIES = {
     "Science & Technology": "28",
 }
 
-
 def _ensure_data():
     """Make sure data directory and videos.json exist."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     if not VIDEOS_FILE.exists():
         VIDEOS_FILE.write_text("[]", encoding="utf-8")
-
 
 def _load_videos() -> list:
     _ensure_data()
@@ -56,30 +51,25 @@ def _load_videos() -> list:
     except (json.JSONDecodeError, FileNotFoundError):
         return []
 
-
 def _save_videos(videos: list):
     _ensure_data()
     VIDEOS_FILE.write_text(json.dumps(videos, indent=2, default=str), encoding="utf-8")
-
 
 def _get_settings() -> dict:
     """Load plugin settings from the DB-backed settings service."""
     from services.plugin_settings_service import get_all_settings
     return get_all_settings("youtube-manager")
 
-
 def _has_api_key() -> bool:
     settings = _get_settings()
     key = settings.get("youtube_api_key", "")
     return bool(key and key.strip())
-
 
 def _mock_youtube_id() -> str:
     """Generate a fake YouTube video ID for mock mode."""
     chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
     import random
     return "".join(random.choices(chars, k=11))
-
 
 # ---------------------------------------------------------------------------
 # Request / Response models
@@ -95,7 +85,6 @@ class UploadRequest(BaseModel):
     category: Optional[str] = "Gaming"
     thumbnail_path: Optional[str] = None
 
-
 class VideoUpdateRequest(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
@@ -103,12 +92,10 @@ class VideoUpdateRequest(BaseModel):
     privacy: Optional[str] = None
     category: Optional[str] = None
 
-
 class MetadataResponse(BaseModel):
     title: str
     description: str
     tags: List[str]
-
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -131,7 +118,6 @@ async def status():
         "pending": len([v for v in videos if v.get("status") == "pending"]),
         "failed": len([v for v in videos if v.get("status") == "failed"]),
     }
-
 
 @router.post("/upload")
 async def upload_video(req: UploadRequest):
@@ -189,7 +175,6 @@ async def upload_video(req: UploadRequest):
         "mode": "live" if _has_api_key() else "mock",
     }
 
-
 @router.get("/videos")
 async def list_videos():
     """List all tracked videos."""
@@ -200,7 +185,6 @@ async def list_videos():
         "videos": videos,
         "total": len(videos),
     }
-
 
 @router.get("/videos/{entity_type}/{entity_id}")
 async def videos_for_entity(entity_type: str, entity_id: str):
@@ -217,7 +201,6 @@ async def videos_for_entity(entity_type: str, entity_id: str):
         "videos": linked,
         "total": len(linked),
     }
-
 
 @router.put("/videos/{video_id}")
 async def update_video(video_id: str, req: VideoUpdateRequest):
@@ -247,7 +230,6 @@ async def update_video(video_id: str, req: VideoUpdateRequest):
     _save_videos(videos)
     return {"success": True, "video": target}
 
-
 @router.delete("/videos/{video_id}")
 async def delete_video(video_id: str):
     """Remove a video from tracking (does not delete from YouTube)."""
@@ -257,7 +239,6 @@ async def delete_video(video_id: str):
         raise HTTPException(status_code=404, detail=f"Video not found: {video_id}")
     _save_videos(filtered)
     return {"success": True, "deleted": video_id}
-
 
 @router.post("/generate-metadata/{entity_type}/{entity_id}")
 async def generate_metadata(entity_type: str, entity_id: str):
@@ -323,7 +304,6 @@ async def generate_metadata(entity_type: str, entity_id: str):
         }
     }
 
-
 @router.get("/asset-videos/{entity_type}/{entity_id}")
 async def list_entity_asset_videos(entity_type: str, entity_id: str):
     """List video files from an entity's assets directory."""
@@ -355,7 +335,6 @@ async def list_entity_asset_videos(entity_type: str, entity_id: str):
         "videos": videos,
         "total": len(videos),
     }
-
 
 @router.get("/categories")
 async def list_categories():


### PR DESCRIPTION
Resolves SBAI-3077

## Summary
Removed F401 unused imports from 22 Python files across plugin backend directories. This is a mechanical lint cleanup with no functional changes - only dead imports were removed.

## Files Changed
22 files in plugins/*/backend/{routes,events}.py:
- assembly-composer, blender-bridge, comfyui-workflows, comparison
- discord-poster, entity-validator, hello-world, import-export-pipeline
- jira-sync, lora-trainer, music-gen, obsidian-vault, pdf-exporter
- prompt-engine, showrunner-exporter, social-publisher, uefn-exporter
- unity-exporter, voice-forge, webhook-automations, youtube-manager

## What Was Removed
- Unused typing imports: Any, Optional, List, Union, Tuple
- Unused stdlib imports: os, json, time, uuid, shutil, asyncio, re
- Unused third-party imports: jsonschema, Field, Depends, Query, UploadFile, File, Form, JSONResponse

## Testing
Verified with Python AST analysis that all top-level F401 violations have been removed. No functional code was modified.