### PR TITLE
SBAI-4637: Publish layout/pack/plugin/skill JSON Schemas + compat metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
               print(f'All rules valid.')
           "
 
-  validate-schemas:
+  validate-schemas-and-assets:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,59 +101,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install "jsonschema>=4.17"
-      - name: Validate JSON Schemas in schemas/
+      - run: pip install "jsonschema>=4.17" "referencing>=0.30" pyyaml
+      - name: Run scripts/validate.py (schema shape + instance validation + semver compat)
+        # --allow-missing-compat grandfathers existing assets that pre-date the
+        # compat.min_core_version requirement (see SBAI-4649). New assets MUST
+        # declare compat.min_core_version. Remove this flag once SBAI-4649 lands.
         run: |
-          python3 -c "
-          import json, sys, pathlib
-          from jsonschema import Draft202012Validator
-
-          errors = []
-          schema_files = sorted(pathlib.Path('schemas').glob('*.json'))
-          if not schema_files:
-              print('ERROR: No schema files found in schemas/', file=sys.stderr)
-              sys.exit(1)
-
-          for schema_file in schema_files:
-              try:
-                  schema = json.loads(schema_file.read_text(encoding='utf-8'))
-              except json.JSONDecodeError as e:
-                  errors.append(f'{schema_file}: JSON parse error: {e}')
-                  continue
-              try:
-                  Draft202012Validator.check_schema(schema)
-              except Exception as e:
-                  errors.append(f'{schema_file}: invalid JSON Schema: {e}')
-
-          if errors:
-              for e in errors:
-                  print(f'ERROR: {e}', file=sys.stderr)
-              sys.exit(1)
-          else:
-              print(f'All {len(schema_files)} schema(s) valid.')
-          "
-
-      - name: Validate plugin manifests in plugins/
-        run: |
-          python3 -c "
-          import json, sys, pathlib
-
-          errors = []
-          REQUIRED_KEYS = {'id', 'name', 'version', 'description', 'type', 'author'}
-          for manifest in sorted(pathlib.Path('plugins').glob('*/plugin.json')):
-              try:
-                  data = json.loads(manifest.read_text(encoding='utf-8'))
-              except json.JSONDecodeError as e:
-                  errors.append(f'{manifest}: JSON parse error: {e}')
-                  continue
-              missing = REQUIRED_KEYS - data.keys()
-              if missing:
-                  errors.append(f'{manifest}: missing required keys: {sorted(missing)}')
-
-          if errors:
-              for e in errors:
-                  print(f'ERROR: {e}', file=sys.stderr)
-              sys.exit(1)
-          else:
-              print(f'All plugin manifests valid.')
-          "
+          python3 scripts/validate.py --allow-missing-compat

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,10 @@ recursive-include studiobrain_templates/templates *.md *.json *.yaml *.yml
 recursive-include studiobrain_templates/rules *.md *.yaml *.yml
 recursive-include studiobrain_templates/plugins *.json *.css *.html *.py *.js
 recursive-include studiobrain_templates/schemas *.json
+recursive-include studiobrain_templates/skills *.yaml *.yml
+include MANIFEST.in
+include README.md
+include LICENSE
+include pyproject.toml
+include package.json
+recursive-include scripts *.py

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,53 @@
+// Type definitions for @studiobrain/templates
+// This is a pure-data package; types cover the runtime entry point only.
+
+export type SchemaName =
+  | "base"
+  | "compat"
+  | "layout"
+  | "pack"
+  | "plugin"
+  | "skill"
+  | "character"
+  | "location"
+  | "item"
+  | "faction"
+  | "brand"
+  | "district"
+  | "job"
+  | "quest"
+  | "event"
+  | "campaign"
+  | "assembly"
+  | "dialogue"
+  | "timeline"
+  | "universe"
+  | "style_bible"
+  | "biome";
+
+export interface JsonSchema {
+  $schema?: string;
+  $id?: string;
+  title?: string;
+  description?: string;
+  type?: string | string[];
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean | Record<string, unknown>;
+  allOf?: unknown[];
+  $defs?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export const ROOT: string;
+export const TEMPLATES_DIR: string;
+export const RULES_DIR: string;
+export const PLUGINS_DIR: string;
+export const SCHEMAS_DIR: string;
+export const SKILLS_DIR: string;
+export const LAYOUTS_DIR: string;
+export const PACKS_DIR: string;
+
+export const SCHEMA_FILES: Readonly<Record<SchemaName, string>>;
+
+export function loadSchema(name: SchemaName | string): JsonSchema;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,74 @@
+"use strict";
+/**
+ * @studiobrain/templates — pure-data entry point.
+ *
+ * Re-exports filesystem paths to bundled directories and a small helper for
+ * loading JSON Schemas. No runtime logic; safe to import from a browser
+ * bundle (paths are string constants, schema loading is opt-in).
+ */
+
+const path = require("path");
+
+const ROOT = __dirname;
+
+const TEMPLATES_DIR = path.join(ROOT, "templates");
+const RULES_DIR = path.join(ROOT, "rules");
+const PLUGINS_DIR = path.join(ROOT, "plugins");
+const SCHEMAS_DIR = path.join(ROOT, "schemas");
+const SKILLS_DIR = path.join(ROOT, "skills");
+const LAYOUTS_DIR = path.join(TEMPLATES_DIR, "Layouts");
+const PACKS_DIR = path.join(TEMPLATES_DIR, "Packs");
+
+/**
+ * Map of logical schema name -> filename inside schemas/.
+ * Keep in sync with schemas/README.md "Schema family overview".
+ */
+const SCHEMA_FILES = Object.freeze({
+  base: "_base.json",
+  compat: "_compat.json",
+  layout: "layout.json",
+  pack: "pack.json",
+  plugin: "plugin.json",
+  skill: "skill.yaml.json",
+  character: "character.json",
+  location: "location.json",
+  item: "item.json",
+  faction: "faction.json",
+  brand: "brand.json",
+  district: "district.json",
+  job: "job.json",
+  quest: "quest.json",
+  event: "event.json",
+  campaign: "campaign.json",
+  assembly: "assembly.json",
+  dialogue: "dialogue.json",
+  timeline: "timeline.json",
+  universe: "universe.json",
+  style_bible: "style_bible.json",
+  biome: "biome.json",
+});
+
+/**
+ * Load a JSON Schema by logical name. Returns the parsed schema object.
+ *
+ * @param {keyof typeof SCHEMA_FILES | string} name
+ * @returns {object}
+ */
+function loadSchema(name) {
+  const filename = SCHEMA_FILES[name] || `${name}.json`;
+  // eslint-disable-next-line global-require
+  return require(path.join(SCHEMAS_DIR, filename));
+}
+
+module.exports = {
+  ROOT,
+  TEMPLATES_DIR,
+  RULES_DIR,
+  PLUGINS_DIR,
+  SCHEMAS_DIR,
+  SKILLS_DIR,
+  LAYOUTS_DIR,
+  PACKS_DIR,
+  SCHEMA_FILES,
+  loadSchema,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiobrain/templates",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "StudioBrain entity templates, generation rules, and plugin SDK",
   "main": "index.js",
   "types": "index.d.ts",
@@ -8,11 +8,16 @@
     "templates/",
     "rules/",
     "plugins/",
+    "schemas/",
+    "skills/",
+    "scripts/validate.py",
     "index.js",
     "index.d.ts"
   ],
   "scripts": {
-    "validate": "python3 scripts/validate.py",
+    "validate": "python3 scripts/validate.py --allow-missing-compat",
+    "validate:strict": "python3 scripts/validate.py",
+    "validate:core": "python3 scripts/validate.py --core-version",
     "lint": "echo 'No linting configured yet'",
     "test": "echo 'No tests configured yet'"
   },
@@ -28,5 +33,5 @@
     "url": "https://github.com/BiloxiStudios/studiobrain-templates.git"
   },
   "author": "Biloxi Studios Inc.",
-  "license": "UNLICENSED"
+  "license": "Apache-2.0"
 }

--- a/plugins/ltx2-pipeline-wasm/plugin.json
+++ b/plugins/ltx2-pipeline-wasm/plugin.json
@@ -8,6 +8,11 @@
   "type": "protocol-adapter",
   "service_type": "video",
   "compatible_services": ["ltx-video", "ltx2"],
+  "compat": {
+    "min_core_version": "0.3.0",
+    "target_api_version": "plugin-manifest/v2",
+    "tested_core_versions": ["0.3.0"]
+  },
   "exports": {
     "adapt_request": {
       "description": "Convert GenerateRequest to LTX-2 server submission payload",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "studiobrain-templates"
-version = "0.2.0"
+version = "0.3.0"
 description = "StudioBrain entity templates, generation rules, and plugin definitions"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -40,4 +40,10 @@ studiobrain_templates = [
     "schemas/**/*.json",
     "skills/**/*.yaml",
     "skills/**/*.yml",
+]
+
+[project.optional-dependencies]
+validate = [
+    "jsonschema>=4.17",
+    "pyyaml>=6.0",
 ]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,80 +1,174 @@
 ---
-title: "StudioBrain Entity JSON Schemas"
-description: "JSON Schema definitions for all StudioBrain entity types, used by the entity-validator plugin to validate YAML frontmatter before write."
+title: "StudioBrain JSON Schemas"
+description: "JSON Schema definitions for entity frontmatter, layouts, template packs, plugins, skills, and shared compat metadata."
 category: "schemas"
-version: "1.0"
+version: "1.1"
 created_date: "2026-04-01"
-last_updated: "2026-04-01"
+last_updated: "2026-07-03"
 ---
 
-# StudioBrain Entity JSON Schemas
+# StudioBrain JSON Schemas
 
-JSON Schema (Draft 2020-12) definitions for all StudioBrain entity types.
-These schemas are the **single source of truth** for what constitutes valid YAML
-frontmatter on an entity markdown file.
+JSON Schema (Draft 2020-12) definitions for every StudioBrain asset type that
+has a structured shape. These schemas are the **single source of truth** for
+what constitutes valid frontmatter / manifest content. Third-party authors
+should treat them as a contract: anything that validates against the schema
+will load in StudioBrain.
 
-## How Schemas are Used
+## Schema family overview
+
+| File | Validates | Used by |
+|---|---|---|
+| `_base.json` | Shared YAML frontmatter fields required by every entity | entity-validator plugin, backend write paths |
+| `<entity_type>.json` | YAML frontmatter for a single entity type (character, location, item, faction, brand, district, job, quest, event, campaign, assembly, dialogue, timeline, universe, style_bible, biome) | entity-validator plugin |
+| `_compat.json` | Shared compat metadata object (semver core version requirements) | Referenced by every asset-level schema below |
+| `layout.json` | `templates/Layouts/*.layout.json` — UI layout files | frontend entity editor |
+| `pack.json` | `templates/Packs/<id>/pack.json` — template pack manifests | pack installer, marketplace |
+| `plugin.json` | `plugins/<id>/plugin.json` — plugin manifests (full / frontend-only / protocol-adapter variants) | plugin loader |
+| `skill.yaml.json` | `skills/Standard/*.yaml` and `skills/User/*.yaml` — AI skill frontmatter (parsed YAML mapping) | skill picker |
+
+## How schemas are used
 
 ```
-Import / Upload / Edit
+Import / Upload / Edit / Install
         ↓
-entity-validator plugin (backend/routes.py)
-        ↓  loads schema from schemas/<entity_type>.json
-validate frontmatter dict against JSON Schema
+scripts/validate.py (CI + install-time)
+        ↓ loads schemas/<name>.json via $ref-aware registry
+validate parsed instance against JSON Schema
         ↓
-  VALID → store entity            INVALID → HTTP 422 + field errors
+  VALID → store / install asset        INVALID → reject with field errors
 ```
 
-The `entity-validator` plugin exposes:
+The validator (`scripts/validate.py`) is the canonical entry point for both
+local development and CI. It accepts several flags:
 
-| Endpoint | Method | Description |
+| Flag | Purpose |
+|---|---|
+| `--core-version X.Y.Z` | Run the semver compat check: refuse any asset whose `compat.min_core_version` is newer than the running core. |
+| `--allow-missing-compat` | Don't error on assets that lack `compat.min_core_version`. Used during the migration period; see SBAI-4649. |
+| `--no-entity-yaml` | Skip entity markdown frontmatter validation (faster local pass). |
+| `--no-compat` | Skip compat enforcement entirely. |
+
+Typical local invocation:
+
+    python3 scripts/validate.py --allow-missing-compat
+    python3 scripts/validate.py --core-version 0.3.0
+
+CI runs:
+
+    python3 scripts/validate.py --allow-missing-compat
+
+## Compatibility metadata (`compat` object)
+
+Every layout, pack, plugin, and skill SHOULD declare a top-level `compat`
+object telling StudioBrain which core version it requires. The shape is
+defined by `schemas/_compat.json` and shared via `$ref` so it is identical
+across all four asset types:
+
+```json
+"compat": {
+  "min_core_version": "0.3.0",
+  "max_core_version": null,
+  "target_api_version": "layout/v1",
+  "tested_core_versions": ["0.3.0"]
+}
+```
+
+| Field | Type | Meaning |
 |---|---|---|
-| `/api/plugins/entity-validator/validate` | POST | Validate a frontmatter dict |
-| `/api/plugins/entity-validator/validate/markdown` | POST | Parse + validate raw markdown |
-| `/api/plugins/entity-validator/schemas` | GET | List available schemas |
-| `/api/plugins/entity-validator/schemas/{entity_type}` | GET | Fetch a specific schema |
+| `min_core_version` | semver string (required) | Minimum core version that can run this asset. |
+| `max_core_version` | semver string or null | Maximum core version (inclusive) known to work; null means unbounded. |
+| `target_api_version` | `<surface>/v<N>` or null | Optional API/protocol version this asset targets (e.g. `plugin-manifest/v2`, `layout/v1`). |
+| `tested_core_versions` | array of semver strings | Informational; versions the author actually tested. |
 
-## Schema Files
+**Semver ordering.** Comparison uses the release triple only — pre-release
+suffixes (`-rc.1`) and build metadata (`+build.42`) are stripped before
+ordering. So `1.0.0-rc.1` is treated as `1.0.0` for compat purposes.
 
-| File | Entity Type | template_category |
+**Why required, not optional.** A missing `min_core_version` means the
+installer cannot protect the user from installing an asset that won't load.
+Strict mode (validator default) treats absence as an error. CI runs in
+migration mode (`--allow-missing-compat`) until SBAI-4649 backfills every
+existing asset.
+
+## Plugin variants (`type` discriminator)
+
+StudioBrain plugins come in three flavors, distinguished by the top-level
+`type` field:
+
+| `type` | What it is | Required keys |
 |---|---|---|
-| `_base.json` | *(shared fields)* | — |
-| `character.json` | `character` | `entity` |
-| `location.json` | `location` | `entity` |
-| `item.json` | `item` | `entity` |
-| `faction.json` | `faction` | `entity` |
-| `brand.json` | `brand` | `entity` |
-| `district.json` | `district` | `entity` |
-| `job.json` | `job` | `entity` |
-| `quest.json` | `quest` | `entity` |
-| `event.json` | `event` | `entity` |
-| `campaign.json` | `campaign` | `entity` |
-| `assembly.json` | `assembly` | `entity` |
-| `dialogue.json` | `dialogue` | `entity` |
-| `timeline.json` | `timeline` | `entity` |
-| `universe.json` | `universe` | `document` |
-| `style_bible.json` | `style_bible` | `document` |
+| `full` | In-process Python plugin with backend routes/event_handlers and frontend pages/panels | `capabilities` |
+| `frontend-only` | No backend routes; uses the generic `plugin_data_routes` for storage | `capabilities.frontend` |
+| `protocol-adapter` | WASM module bridging an external service (e.g. ltx-video); implements `adapt_request`, `adapt_response`, `health_check` | `exports`, `service_type` |
 
-## Required Fields (all entities)
+The `plugin.json` schema uses `allOf` with `if/then` branches to enforce
+the right shape per variant.
 
-| Field | Type | Constraint |
+## Plugin settings schema (`settings_schema`)
+
+A plugin's `settings_schema` is a free-form object whose keys are setting
+ids and values describe the field. Allowed `type` values:
+
+| `type` | Rendered widget | Notes |
 |---|---|---|
-| `id` | string | `^[a-z0-9][a-z0-9_]*$` |
-| `entity_type` | string | enum of known entity types |
-| `template_version` | string | `^\d+\.\d+$` |
-| `template_category` | string | `entity`, `document`, or `core` |
-| `created_date` | string | `^\d{4}-\d{2}-\d{2}$` |
-| `last_updated` | string | `^\d{4}-\d{2}-\d{2}$` |
+| `string` | text input | |
+| `boolean` | toggle | |
+| `integer` / `number` | numeric input | supports `min`/`max`/`step` |
+| `select` | dropdown | requires `options` array |
+| `color` | color picker | |
+| `secret` | masked input | stored separately; use for API keys/tokens |
+| `object` | nested fields | use `properties` for sub-shape |
 
-## Item-Specific Required Fields
+`options` items may be either a plain string (`"markdown"`) or a
+`{value, label}` object — both shapes appear in the wild.
 
-| Field | Type | Constraint |
-|---|---|---|
-| `item_type` | string | `weapon`, `consumable`, `key_item`, `material`, `collectible`, `cosmetic`, `currency` |
+## Adding a new entity type
 
-## Adding a New Entity Type
-
-1. Add a new `<entity_type>.json` file in this directory following the same `allOf` + `$ref` pattern.
+1. Add a new `<entity_type>.json` file in this directory following the same
+   `allOf` + `$ref` pattern as `character.json`.
 2. Add the `entity_type` to the `enum` in `_base.json`.
-3. Add the new entity type to the `ENTITY_SCHEMAS` map in `plugins/entity-validator/backend/routes.py`.
-4. Add the corresponding template in `templates/Standard/` and rules file in `rules/`.
+3. Add the new entity type to the `ENTITY_SCHEMAS` map in
+   `plugins/entity-validator/backend/routes.py`.
+4. Add the corresponding template in `templates/Standard/` and rules file in
+   `rules/`.
+5. If the entity needs a UI layout, add `templates/Layouts/<entity_type>.layout.json`
+   (validated against `layout.json`).
+
+## Adding a new schema
+
+1. Pick a kebab-or-snake-case file name (existing convention: `<noun>.json`
+   for JSON files, `<noun>.yaml.json` for schemas that validate parsed YAML).
+2. Set `$schema` to `https://json-schema.org/draft/2020-12/schema` and
+   `$id` to `https://studiobrain.biloxistudios.com/schemas/<filename>`.
+3. If the asset has compat requirements, add a `"compat": {"$ref": "./_compat.json"}`
+   property and require it.
+4. Update this README's "Schema family overview" table.
+5. Add a check function in `scripts/validate.py` and wire it into `main()`.
+
+## Schema files
+
+| File | Description |
+|---|---|
+| `_base.json` | Shared entity frontmatter fields |
+| `_compat.json` | Shared compat metadata (min_core_version semver) |
+| `character.json` | Character entity schema |
+| `location.json` | Location entity schema |
+| `item.json` | Item entity schema |
+| `faction.json` | Faction entity schema |
+| `brand.json` | Brand entity schema |
+| `district.json` | District entity schema |
+| `job.json` | Job entity schema |
+| `quest.json` | Quest entity schema |
+| `event.json` | Event entity schema |
+| `campaign.json` | Campaign entity schema |
+| `assembly.json` | Assembly entity schema |
+| `dialogue.json` | Dialogue entity schema |
+| `timeline.json` | Timeline entity schema |
+| `universe.json` | Universe document schema |
+| `style_bible.json` | Style bible document schema |
+| `biome.json` | Biome entity schema |
+| `layout.json` | UI layout contract (templates/Layouts/*.layout.json) |
+| `pack.json` | Template pack contract (templates/Packs/<id>/pack.json) |
+| `plugin.json` | Plugin manifest contract (full / frontend-only / protocol-adapter) |
+| `skill.yaml.json` | AI skill frontmatter contract (skills/*.yaml) |

--- a/schemas/_compat.json
+++ b/schemas/_compat.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studiobrain.biloxistudios.com/schemas/_compat.json",
+  "title": "StudioBrain Compatibility Metadata",
+  "description": "Shared schema fragment describing version-compatibility metadata that StudioBrain assets may declare. Consumed by the installer / validator to refuse assets that require a newer core than is running.",
+  "type": "object",
+  "properties": {
+    "min_core_version": {
+      "type": "string",
+      "description": "Minimum StudioBrain core version (semver, MAJOR.MINOR.PATCH) required to install and run this asset. Compared against the running core's version at install time using semver ordering (any pre-release suffix is stripped before comparison).",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "max_core_version": {
+      "type": ["string", "null"],
+      "description": "Optional maximum core version (inclusive) this asset is known to work against. Null or absent means unbounded.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "target_api_version": {
+      "type": ["string", "null"],
+      "description": "Optional API/protocol version this asset targets. Free-form but should match a version advertised by core (e.g. 'plugin-manifest/v2', 'layout/v1').",
+      "pattern": "^[a-z0-9._-]+/v\\d+(?:\\.\\d+)?$"
+    },
+    "tested_core_versions": {
+      "type": "array",
+      "description": "List of core versions the author has actually tested against. Informational only; not enforced.",
+      "items": {
+        "type": "string",
+        "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+      }
+    }
+  },
+  "required": ["min_core_version"],
+  "additionalProperties": true
+}

--- a/schemas/layout.json
+++ b/schemas/layout.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studiobrain.biloxistudios.com/schemas/layout.json",
+  "title": "StudioBrain Layout Schema",
+  "description": "JSON Schema for *.layout.json files under templates/Layouts/. A layout describes how an entity editor renders its fields: sections, columns, field widgets, plugin slots, and view configuration.",
+  "type": "object",
+  "required": ["entity_type", "version", "sections"],
+  "properties": {
+    "entity_type": {
+      "type": "string",
+      "description": "Entity type this layout renders. Must match an entity_type in schemas/_base.json.",
+      "enum": [
+        "character",
+        "location",
+        "item",
+        "faction",
+        "brand",
+        "district",
+        "job",
+        "quest",
+        "event",
+        "campaign",
+        "assembly",
+        "dialogue",
+        "timeline",
+        "universe",
+        "style_bible",
+        "biome"
+      ]
+    },
+    "version": {
+      "type": "string",
+      "description": "Layout format version. Accepts MAJOR.MINOR ('1.0') or full semver MAJOR.MINOR.PATCH ('1.0.0').",
+      "pattern": "^\\d+\\.\\d+(?:\\.\\d+)?(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "compat": {
+      "$ref": "./_compat.json",
+      "description": "Compatibility metadata. min_core_version is required so the installer can refuse layouts targeting a newer core than is running."
+    },
+    "sections": {
+      "type": "array",
+      "description": "Ordered list of layout sections. Each section is a panel/group in the editor.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Section identifier; must be unique within the layout. Snake_case or kebab-case (auto-generated block IDs may be 'block_<timestamp>').",
+            "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+          },
+          "title": {
+            "type": ["string", "null"],
+            "description": "Optional human-readable section title. May be null when the section is a pure component slot."
+          },
+          "icon": {
+            "type": ["string", "null"],
+            "description": "Optional icon identifier (lucide icon name or plugin-provided)."
+          },
+          "columns": {
+            "type": ["integer", "null"],
+            "description": "Number of grid columns for field layout (typically 1, 2, or 3).",
+            "minimum": 1,
+            "maximum": 6
+          },
+          "collapsed_default": {
+            "type": ["boolean", "null"],
+            "description": "Whether the section is collapsed by default in the UI."
+          },
+          "fields": {
+            "type": ["array", "null"],
+            "description": "Form fields rendered inside this section. Null when the section is a component slot.",
+            "items": {"$ref": "#/$defs/field"}
+          },
+          "component": {
+            "type": ["string", "null"],
+            "description": "Component identifier for non-field sections (e.g. 'entity-workflow-trigger', 'plugin:<plugin>:<component>', 'entity-assets'). Null for field sections."
+          },
+          "component_config": {
+            "type": ["object", "null"],
+            "description": "Free-form configuration passed to the component.",
+            "additionalProperties": true
+          },
+          "component_source": {
+            "type": ["string", "null"],
+            "description": "Source of the component ('builtin', a plugin id, etc.).",
+            "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+          },
+          "editor_component": {"type": ["string", "null"]},
+          "viewer_component": {"type": ["string", "null"]}
+        },
+        "additionalProperties": true
+      }
+    },
+    "view_config": {
+      "type": ["object", "null"],
+      "description": "Optional view-layer configuration (e.g. {layout_driven: true}).",
+      "additionalProperties": true
+    },
+    "updated_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO-8601 timestamp the layout was last edited."
+    },
+    "created_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO-8601 timestamp the layout was created."
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "field": {
+      "type": "object",
+      "required": ["key", "ui_component"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Frontmatter key this field binds to. May use dotted paths (e.g. 'color_palette.primary') for nested fields.",
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z0-9_-]+)*$"
+        },
+        "label": {
+          "type": ["string", "null"],
+          "description": "Human-readable label shown above the field."
+        },
+        "ui_component": {
+          "type": "string",
+          "description": "Widget registry identifier (text, textarea, number, select, multi_select, toggle, read-only-text, image-upload, color-picker, markdown, entity-reference, ...). 'plugin:<plugin>:<widget>' is reserved for plugin-provided widgets."
+        },
+        "required": {
+          "type": ["boolean", "null"],
+          "description": "Whether the user must fill this field."
+        },
+        "placeholder": {
+          "type": ["string", "null"],
+          "description": "Placeholder text shown when the field is empty."
+        },
+        "help": {
+          "type": ["string", "null"],
+          "description": "Help text shown under the field."
+        },
+        "default": {
+          "description": "Default value when the entity is created with no value supplied. Type depends on ui_component.",
+          "additionalProperties": true
+        },
+        "options": {
+          "type": ["array", "null"],
+          "description": "For select / multi_select / radio widgets.",
+          "items": {
+            "type": "object",
+            "required": ["value", "label"],
+            "properties": {
+              "value": {
+                "type": ["string", "integer", "boolean", "number"]
+              },
+              "label": {"type": "string"}
+            },
+            "additionalProperties": true
+          }
+        },
+        "options_source": {
+          "type": ["string", "null"],
+          "description": "Reference to a dynamic options source (e.g. 'enum:faction' or 'plugin:<plugin>:<fn>')."
+        },
+        "auto_generate_from": {
+          "type": ["string", "null"],
+          "description": "When set, the field value is auto-generated from the referenced field (e.g. id from name)."
+        },
+        "rows": {
+          "type": ["integer", "null"],
+          "description": "For textarea widgets: visible row count.",
+          "minimum": 1,
+          "maximum": 50
+        },
+        "min": {"type": ["integer", "number", "null"]},
+        "max": {"type": ["integer", "number", "null"]},
+        "step": {"type": ["integer", "number", "null"]},
+        "multiple": {"type": ["boolean", "null"]},
+        "accept": {
+          "type": ["string", "array", "null"],
+          "items": {"type": "string"}
+        },
+        "validation": {
+          "type": ["object", "null"],
+          "description": "Inline validation hints (regex, min/max length, etc.).",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/pack.json
+++ b/schemas/pack.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studiobrain.biloxistudios.com/schemas/pack.json",
+  "title": "StudioBrain Template Pack Schema",
+  "description": "JSON Schema for pack.json files under templates/Packs/<pack-id>/. A pack groups templates, rules, layouts, and example entities into an installable unit. Meta-packs reference other packs via 'includes' rather than embedding content.",
+  "type": "object",
+  "required": ["id", "name", "version"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique pack identifier; must match the pack directory name. snake_case or kebab-case.",
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable pack name shown in the marketplace and installer UI."
+    },
+    "version": {
+      "type": "string",
+      "description": "Pack version (semver MAJOR.MINOR.PATCH).",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Free-form description shown in the marketplace listing."
+    },
+    "author": {
+      "type": ["string", "null"],
+      "description": "Author name or organization."
+    },
+    "license": {
+      "type": ["string", "null"],
+      "description": "SPDX license identifier (e.g. 'Apache-2.0')."
+    },
+    "compat": {
+      "$ref": "./_compat.json",
+      "description": "Compatibility metadata. min_core_version is required so the installer can refuse packs targeting a newer core than is running."
+    },
+    "entity_types": {
+      "type": "array",
+      "description": "Entity types this pack provides content for. Informational; not strictly enforced against contents.",
+      "items": {"type": "string"}
+    },
+    "categories": {
+      "type": "array",
+      "description": "Marketplace categories (e.g. 'narrative', 'game-dev', 'film-tv', 'world-building').",
+      "items": {"type": "string"}
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "icon": {
+      "type": ["string", "null"],
+      "description": "Path to an icon asset relative to the pack root, or null."
+    },
+    "is_default": {
+      "type": ["boolean", "null"],
+      "description": "When true, the pack is installed automatically on new projects."
+    },
+    "auto_install": {
+      "type": ["boolean", "null"],
+      "description": "When true, the pack is queued for install on first run."
+    },
+    "is_meta_pack": {
+      "type": ["boolean", "null"],
+      "description": "When true, the pack only references other packs via 'includes' and carries no direct content."
+    },
+    "includes": {
+      "type": "array",
+      "description": "List of pack ids that this meta-pack aggregates. Empty for non-meta packs.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_-]*$"
+      }
+    },
+    "templates": {
+      "type": "array",
+      "description": "Template markdown files (paths relative to the pack root). Empty for meta-packs.",
+      "items": {"type": "string"}
+    },
+    "rules": {
+      "type": "array",
+      "description": "Rule files (paths relative to the pack root). Empty for meta-packs.",
+      "items": {"type": "string"}
+    },
+    "layouts": {
+      "type": "array",
+      "description": "Layout JSON files (paths relative to the pack root). Empty for meta-packs.",
+      "items": {"type": "string"}
+    },
+    "examples": {
+      "type": "array",
+      "description": "Example entity markdown files (paths relative to the pack root).",
+      "items": {"type": "string"}
+    },
+    "skills": {
+      "type": "array",
+      "description": "Skill YAML files (paths relative to the pack root).",
+      "items": {"type": "string"}
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Plugin directories (names relative to plugins/) bundled by the pack.",
+      "items": {"type": "string"}
+    },
+    "homepage": {
+      "type": ["string", "null"],
+      "format": "uri"
+    },
+    "repository": {
+      "type": ["string", "null"],
+      "format": "uri"
+    }
+  },
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "if": {
+        "required": ["is_meta_pack"],
+        "properties": {"is_meta_pack": {"const": true}}
+      },
+      "then": {
+        "description": "Meta-packs must declare at least one include; should not carry direct templates.",
+        "required": ["includes"]
+      }
+    }
+  ]
+}

--- a/schemas/plugin.json
+++ b/schemas/plugin.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studiobrain.biloxistudios.com/schemas/plugin.json",
+  "title": "StudioBrain Plugin Manifest Schema",
+  "description": "JSON Schema for plugin.json files under plugins/<plugin-id>/. StudioBrain supports two plugin variants distinguished by the 'type' field: 'full' (Python backend + HTML frontend, runs in-process) and 'protocol-adapter' (WASM module implementing adapt_request / adapt_response / health_check for an external service).",
+  "type": "object",
+  "required": ["id", "name", "version", "description", "type"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique plugin identifier; must match the plugin directory name. snake_case or kebab-case.",
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string",
+      "description": "Plugin version (semver MAJOR.MINOR.PATCH).",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "description": {"type": "string"},
+    "type": {
+      "type": "string",
+      "description": "Plugin variant. 'full' = in-process Python plugin (backend routes + frontend pages/panels); 'frontend-only' = no backend routes, just frontend surfaces (uses generic plugin_data_routes for storage); 'protocol-adapter' = WASM module implementing the protocol-adapter contract.",
+      "enum": ["full", "frontend-only", "protocol-adapter"]
+    },
+    "author": {"type": ["string", "null"]},
+    "license": {
+      "type": ["string", "null"],
+      "description": "SPDX identifier (e.g. 'Apache-2.0')."
+    },
+    "category": {
+      "type": ["string", "null"],
+      "description": "Optional category slug for marketplace grouping."
+    },
+    "compat": {
+      "$ref": "./_compat.json",
+      "description": "Compatibility metadata. min_core_version is required so the installer can refuse plugins targeting a newer core than is running."
+    },
+    "accent_color": {
+      "type": ["string", "null"],
+      "description": "CSS color or var(--*) for plugin accent."
+    }
+  },
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "if": {
+        "properties": {"type": {"const": "full"}}
+      },
+      "then": {
+        "title": "Full Plugin",
+        "description": "Shape for type=full plugins.",
+        "required": ["capabilities"],
+        "properties": {
+          "id": {},
+          "name": {},
+          "version": {},
+          "description": {},
+          "type": {},
+          "author": {},
+          "license": {},
+          "category": {},
+          "compat": {},
+          "accent_color": {},
+          "capabilities": {
+            "type": "object",
+            "description": "Capability map. Backed by Python routes/event_handlers; frontend by pages/panels.",
+            "properties": {
+              "backend": {
+                "type": ["object", "null"],
+                "properties": {
+                  "routes": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                  },
+                  "event_handlers": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                  }
+                },
+                "additionalProperties": true
+              },
+              "frontend": {
+                "type": ["object", "null"],
+                "properties": {
+                  "pages": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["id", "route", "label"],
+                      "properties": {
+                        "id": {"type": "string", "pattern": "^[a-z][a-z0-9_-]*$"},
+                        "route": {"type": "string", "pattern": "^/"},
+                        "label": {"type": "string"},
+                        "icon": {"type": ["string", "null"]},
+                        "nav_section": {"type": ["string", "null"]}
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "panels": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["id", "label"],
+                      "properties": {
+                        "id": {"type": "string", "pattern": "^[a-z][a-z0-9_-]*$"},
+                        "label": {"type": "string"},
+                        "location": {
+                          "type": ["string", "null"],
+                          "description": "Where the panel mounts. Older plugins may use 'type' as an alias.",
+                          "enum": ["entity-sidebar", "entity-tab", "dashboard-sidebar", "page-toolbar", null]
+                        },
+                        "type": {
+                          "type": ["string", "null"],
+                          "description": "Alias for 'location' on legacy panels."
+                        },
+                        "file": {
+                          "type": ["string", "null"],
+                          "description": "Path to the HTML file implementing the panel."
+                        },
+                        "icon": {"type": ["string", "null"]},
+                        "description": {"type": ["string", "null"]}
+                      },
+                      "additionalProperties": true
+                    }
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "dependencies": {
+            "type": ["object", "null"],
+            "description": "External runtime dependencies. 'python' is a list of pip specifiers; 'wasm' would be a list of WASM module URLs.",
+            "properties": {
+              "python": {
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              "wasm": {
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              "plugins": {
+                "type": "array",
+                "description": "Other plugin ids this plugin depends on.",
+                "items": {"type": "string", "pattern": "^[a-z][a-z0-9_-]*$"}
+              }
+            },
+            "additionalProperties": true
+          },
+          "permissions": {
+            "type": "array",
+            "description": "Permission grants the plugin requests. Use '<domain>:<scope>' (e.g. 'entity:read', 'network:local', 'filesystem:write').",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$"
+            }
+          },
+          "settings_schema": {
+            "type": ["object", "null"],
+            "description": "Per-plugin settings schema. Each key is a setting id; value describes the field.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Setting widget type. 'secret' is rendered as a masked input and stored separately from regular settings; 'object' is a nested object with its own 'properties' map mirroring the parent shape.",
+                  "enum": ["string", "boolean", "integer", "number", "select", "color", "secret", "object"]
+                },
+                "label": {"type": "string"},
+                "description": {"type": ["string", "null"]},
+                "required": {"type": ["boolean", "null"]},
+                "default": {},
+                "scope": {
+                  "type": ["string", "null"],
+                  "enum": ["user", "instance", "tenant"]
+                },
+                "options": {
+                  "type": ["array", "null"],
+                  "description": "For select widgets. Items may be either a plain string or a {value, label} object.",
+                  "items": {
+                    "oneOf": [
+                      {"type": "string"},
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {},
+                          "label": {"type": "string"}
+                        },
+                        "additionalProperties": true
+                      }
+                    ]
+                  }
+                },
+                "properties": {
+                  "type": ["object", "null"],
+                  "description": "Nested settings for type='object'. Maps sub-key -> setting definition (same shape as the parent).",
+                  "additionalProperties": true
+                },
+                "test_endpoint": {"type": ["string", "null"]}
+              },
+              "additionalProperties": true
+            }
+          },
+          "data_schema": {
+            "type": ["object", "null"],
+            "description": "Optional description of plugin-owned data records.",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {"type": {"const": "protocol-adapter"}}
+      },
+      "then": {
+        "title": "Protocol Adapter Plugin",
+        "description": "Shape for type=protocol-adapter plugins (WASM).",
+        "required": ["exports", "service_type"],
+        "properties": {
+          "id": {},
+          "name": {},
+          "version": {},
+          "description": {},
+          "type": {},
+          "author": {},
+          "license": {},
+          "category": {},
+          "compat": {},
+          "accent_color": {},
+          "service_type": {
+            "type": "string",
+            "description": "Service category this adapter bridges (e.g. 'video', 'image', 'audio', 'text', '3d')."
+          },
+          "compatible_services": {
+            "type": "array",
+            "description": "External service ids this adapter knows how to talk to (e.g. ['ltx-video', 'ltx2']).",
+            "items": {"type": "string"}
+          },
+          "exports": {
+            "type": "object",
+            "description": "WASM exports the protocol-adapter contract requires.",
+            "required": ["adapt_request", "adapt_response", "health_check"],
+            "properties": {
+              "adapt_request": {
+                "type": "object",
+                "properties": {
+                  "description": {"type": ["string", "null"]},
+                  "input": {"type": ["string", "null"]},
+                  "output": {"type": ["string", "null"]}
+                },
+                "additionalProperties": true
+              },
+              "adapt_response": {
+                "type": "object",
+                "properties": {
+                  "description": {"type": ["string", "null"]},
+                  "input": {"type": ["string", "null"]},
+                  "output": {"type": ["string", "null"]}
+                },
+                "additionalProperties": true
+              },
+              "health_check": {
+                "type": "object",
+                "properties": {
+                  "description": {"type": ["string", "null"]},
+                  "input": {"type": ["string", "null"]},
+                  "output": {"type": ["string", "null"]}
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "settings": {
+            "type": ["array", "null"],
+            "description": "Adapter settings schema (array form, mirrors the SDK adapter-toolkit convention).",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "routes": {
+            "type": ["array", "null"],
+            "description": "Adapter HTTP routes (array form).",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/skill.yaml.json
+++ b/schemas/skill.yaml.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studiobrain.biloxistudios.com/schemas/skill.yaml.json",
+  "title": "StudioBrain Skill Schema",
+  "description": "JSON Schema for the YAML frontmatter and top-level keys of a StudioBrain skill file (skills/Standard/*.yaml and skills/User/*.yaml). Validates the parsed YAML mapping (NOT the raw text). A skill describes an AI capability the user can invoke from the UI: input shape, prompt templates, target entity scope, and entitlement gating.",
+  "type": "object",
+  "required": ["skill_id", "name", "description", "version", "category", "applies_to", "min_tier"],
+  "properties": {
+    "skill_id": {
+      "type": "string",
+      "description": "Unique skill identifier; snake_case.",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable skill name."
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description shown in the skill picker UI."
+    },
+    "version": {
+      "type": ["string", "number"],
+      "description": "Skill version. String preferred (semver MAJOR.MINOR.PATCH or 'MAJOR.MINOR'); numeric '1.0' is tolerated for legacy reasons."
+    },
+    "category": {
+      "type": "string",
+      "description": "Functional category for grouping in the picker.",
+      "enum": ["generation", "validation", "analysis", "transformation", "utility", "import", "export"]
+    },
+    "applies_to": {
+      "description": "Entity scope the skill applies to. Either a single entity_type string or 'all'.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "all",
+            "character",
+            "location",
+            "item",
+            "faction",
+            "brand",
+            "district",
+            "job",
+            "quest",
+            "event",
+            "campaign",
+            "assembly",
+            "dialogue",
+            "timeline",
+            "universe",
+            "style_bible",
+            "biome"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "Runtime capabilities the skill requires (e.g. 'entity_read', 'entity_list', 'ai_generate', 'filesystem:read').",
+      "items": {"type": "string"}
+    },
+    "min_tier": {
+      "type": ["string", "integer"],
+      "description": "Minimum entitlement tier required to invoke the skill. Either the tier_id ('free', 'indie', 'team', 'enterprise') or the integer ordinal (0..3).",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": ["free", "indie", "team", "enterprise"]
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        }
+      ]
+    },
+    "compat": {
+      "$ref": "./_compat.json",
+      "description": "Compatibility metadata. min_core_version is required so the runtime can refuse to load skills targeting a newer core than is running."
+    },
+    "inputs": {
+      "type": ["object", "null"],
+      "description": "Input contract for the skill invocation.",
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "optional": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "additionalProperties": true
+    },
+    "outputs": {
+      "type": ["object", "null"],
+      "description": "Optional description of the skill's output shape.",
+      "additionalProperties": true
+    },
+    "prompts": {
+      "type": ["object", "null"],
+      "description": "Prompt templates the skill uses. Conventionally has 'system' and 'user' keys with templated strings.",
+      "additionalProperties": true
+    },
+    "examples": {
+      "type": ["array", "null"],
+      "items": {"type": "string"}
+    },
+    "homepage": {
+      "type": ["string", "null"],
+      "format": "uri"
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""StudioBrain templates — schema + compat validator.
+
+Runs every CI-facing check from one place:
+
+  1. Confirms every schema file in ``schemas/`` is a valid JSON Schema (Draft 2020-12).
+  2. Validates every ``*.layout.json`` against ``schemas/layout.json``.
+  3. Validates every ``pack.json`` against ``schemas/pack.json``.
+  4. Validates every ``plugin.json`` against ``schemas/plugin.json``.
+  5. Validates every skill YAML frontmatter against ``schemas/skill.yaml.json``.
+  6. Validates entity markdown YAML frontmatter against ``schemas/<entity_type>.json``
+     (best-effort — skipped if pyyaml is unavailable).
+  7. Enforces compat metadata: every layout / pack / plugin / skill MUST declare
+     ``compat.min_core_version`` as a semver string. When ``--core-version`` is
+     supplied, the script also refuses assets whose ``min_core_version`` is
+     newer than the running core.
+
+Intended for both local development and CI:
+
+    python3 scripts/validate.py                  # full validation pass
+    python3 scripts/validate.py --core-version 0.5.0
+    python3 scripts/validate.py --no-entity-yaml # skip entity frontmatter checks
+
+Exit code is non-zero if any validation fails.
+
+This script deliberately has zero runtime dependencies beyond the Python
+standard library when ``--no-entity-yaml`` is set, so it can run in a
+minimal CI image. When ``jsonschema`` and ``pyyaml`` are available they
+are used; otherwise checks depending on them degrade gracefully.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import pathlib
+from typing import Any, Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = ROOT / "schemas"
+TEMPLATES_DIR = ROOT / "templates"
+PLUGINS_DIR = ROOT / "plugins"
+SKILLS_DIR = ROOT / "skills"
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+
+def _err(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+
+
+def _info(msg: str) -> None:
+    print(msg)
+
+
+def _parse_semver(value: str) -> tuple[int, int, int]:
+    """Parse a semver string into a (major, minor, patch) tuple for ordering.
+
+    Pre-release/build metadata are stripped — compat ordering is purely on the
+    release triple.
+    """
+    match = SEMVER_RE.match(value)
+    if not match:
+        raise ValueError(f"not a semver string: {value!r}")
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _semver_le(a: str, b: str) -> bool:
+    """Return True if ``a <= b`` in semver ordering (pre-release stripped)."""
+    return _parse_semver(a) <= _parse_semver(b)
+
+
+# ----- Optional-dependency shims -------------------------------------------------
+
+try:
+    import yaml  # type: ignore
+    HAVE_YAML = True
+except ImportError:
+    HAVE_YAML = False
+
+try:
+    from jsonschema import Draft202012Validator  # type: ignore
+    HAVE_JSONSCHEMA = True
+    # RefResolver is deprecated in jsonschema >= 4.18 in favor of the `referencing`
+    # library. We only need it as a fallback for very old jsonschema versions, so
+    # import it lazily and silence the deprecation warning.
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            from jsonschema import RefResolver  # type: ignore  # noqa: F401
+        except ImportError:  # pragma: no cover
+            RefResolver = None  # type: ignore
+except ImportError:
+    HAVE_JSONSCHEMA = False
+
+
+# ----- Schema loading ------------------------------------------------------------
+
+_SCHEMA_CACHE: dict[str, dict[str, Any]] = {}
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    """Load a schema by file name (e.g. 'layout.json') from schemas/."""
+    if name not in _SCHEMA_CACHE:
+        path = SCHEMAS_DIR / name
+        if not path.exists():
+            raise FileNotFoundError(f"schema not found: {path}")
+        with path.open(encoding="utf-8") as fh:
+            _SCHEMA_CACHE[name] = json.load(fh)
+    return _SCHEMA_CACHE[name]
+
+
+def make_validator(schema_name: str):
+    """Build a Draft202012Validator with local $ref resolution."""
+    schema = load_schema(schema_name)
+    if HAVE_JSONSCHEMA:
+        # Newer jsonschema versions deprecate RefResolver but still ship it.
+        # We use a referencing-based registry when available, falling back to
+        # RefResolver for older versions.
+        try:
+            from referencing import Registry, Resource  # type: ignore
+            resources = []
+            for schema_file in SCHEMAS_DIR.glob("*.json"):
+                try:
+                    data = json.loads(schema_file.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                # Resource key is the $id URL.
+                rid = data.get("$id") or schema_file.name
+                resources.append((rid, Resource.from_contents(data)))
+            registry = Registry().with_resources(resources)
+            return Draft202012Validator(schema, registry=registry)
+        except ImportError:
+            if RefResolver is not None:
+                base_uri = schema.get("$id", "")
+                resolver = RefResolver(base_uri=base_uri, referrer=schema)
+                return Draft202012Validator(schema, resolver=resolver)
+            return Draft202012Validator(schema)
+    return None
+
+
+# ----- Check helpers -------------------------------------------------------------
+
+def check_schemas_are_valid() -> list[str]:
+    """Ensure every file in schemas/ is itself a valid JSON Schema."""
+    errors: list[str] = []
+    for schema_file in sorted(SCHEMAS_DIR.glob("*.json")):
+        try:
+            schema = json.loads(schema_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{schema_file}: JSON parse error: {exc}")
+            continue
+        if HAVE_JSONSCHEMA:
+            try:
+                Draft202012Validator.check_schema(schema)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{schema_file}: invalid JSON Schema: {exc}")
+        else:
+            # Without jsonschema we can still confirm shape basics.
+            if not isinstance(schema, dict):
+                errors.append(f"{schema_file}: schema is not an object")
+            elif "$schema" not in schema:
+                errors.append(f"{schema_file}: missing $schema keyword")
+    return errors
+
+
+def _validate_instance(instance: Any, schema_name: str, label: str) -> list[str]:
+    if not HAVE_JSONSCHEMA:
+        return []  # graceful skip
+    validator = make_validator(schema_name)
+    if validator is None:
+        return []
+    errs = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+    return [
+        f"{label}: {err.message} (at /{'/'.join(str(p) for p in err.path) or '<root>'})"
+        for err in errs
+    ]
+
+
+def check_layouts() -> list[str]:
+    errors: list[str] = []
+    layout_dir = TEMPLATES_DIR / "Layouts"
+    if not layout_dir.exists():
+        return errors
+    for layout_file in sorted(layout_dir.glob("*.layout.json")):
+        try:
+            data = json.loads(layout_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{layout_file}: JSON parse error: {exc}")
+            continue
+        errors.extend(_validate_instance(data, "layout.json", str(layout_file)))
+    return errors
+
+
+def check_packs() -> list[str]:
+    errors: list[str] = []
+    packs_dir = TEMPLATES_DIR / "Packs"
+    if not packs_dir.exists():
+        return errors
+    for pack_file in sorted(packs_dir.glob("*/pack.json")):
+        try:
+            data = json.loads(pack_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{pack_file}: JSON parse error: {exc}")
+            continue
+        errors.extend(_validate_instance(data, "pack.json", str(pack_file)))
+    return errors
+
+
+def check_plugins() -> list[str]:
+    errors: list[str] = []
+    for manifest in sorted(PLUGINS_DIR.glob("*/plugin.json")):
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{manifest}: JSON parse error: {exc}")
+            continue
+        errors.extend(_validate_instance(data, "plugin.json", str(manifest)))
+    return errors
+
+
+def check_skills() -> list[str]:
+    errors: list[str] = []
+    if not HAVE_YAML:
+        _info("NOTE: pyyaml not installed — skipping skill YAML frontmatter validation.")
+        return errors
+    for skill_dir in [SKILLS_DIR / "Standard", SKILLS_DIR / "User"]:
+        if not skill_dir.exists():
+            continue
+        for skill_file in sorted(skill_dir.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(skill_file.read_text(encoding="utf-8"))
+            except yaml.YAMLError as exc:
+                errors.append(f"{skill_file}: YAML parse error: {exc}")
+                continue
+            if not isinstance(data, dict):
+                errors.append(f"{skill_file}: top-level YAML is not a mapping")
+                continue
+            errors.extend(_validate_instance(data, "skill.yaml.json", str(skill_file)))
+    return errors
+
+
+def check_entity_frontmatter() -> list[str]:
+    if not HAVE_YAML or not HAVE_JSONSCHEMA:
+        _info("NOTE: pyyaml or jsonschema not installed — skipping entity YAML frontmatter validation.")
+        return []
+    errors: list[str] = []
+    skip_files = {"README.md"}
+    # Template / example files use placeholder values ([snake_case_name], YYYY-MM-DD)
+    # by design — they are not real entity instances and must not be schema-validated.
+    skip_suffixes = ("_TEMPLATE.md",)
+    skip_path_parts = {"templates", "examples"}
+    for md in sorted(TEMPLATES_DIR.rglob("*.md")):
+        if md.name in skip_files:
+            continue
+        if any(md.name.endswith(suffix) for suffix in skip_suffixes):
+            continue
+        # Skip files inside a pack's templates/ or examples/ directory.
+        if skip_path_parts & set(md.parts):
+            continue
+        text = md.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            errors.append(f"{md}: missing YAML frontmatter delimiter")
+            continue
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            errors.append(f"{md}: malformed frontmatter (no closing ---)")
+            continue
+        try:
+            data = yaml.safe_load(parts[1])
+        except yaml.YAMLError as exc:
+            errors.append(f"{md}: YAML parse error: {exc}")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{md}: frontmatter is not a YAML mapping")
+            continue
+        entity_type = data.get("entity_type")
+        if not entity_type:
+            continue
+        schema_file = SCHEMAS_DIR / f"{entity_type}.json"
+        if not schema_file.exists():
+            errors.append(f"{md}: no schema for entity_type={entity_type!r}")
+            continue
+        errors.extend(_validate_instance(data, f"{entity_type}.json", str(md)))
+    return errors
+
+
+# ----- Compat enforcement --------------------------------------------------------
+
+def _walk_compat_objects() -> Iterable[tuple[pathlib.Path, dict[str, Any], str]]:
+    """Yield (path, parsed_dict, kind) for every asset that should carry compat metadata."""
+    layout_dir = TEMPLATES_DIR / "Layouts"
+    if layout_dir.exists():
+        for f in layout_dir.glob("*.layout.json"):
+            try:
+                yield f, json.loads(f.read_text(encoding="utf-8")), "layout"
+            except json.JSONDecodeError:
+                continue
+    packs_dir = TEMPLATES_DIR / "Packs"
+    if packs_dir.exists():
+        for f in packs_dir.glob("*/pack.json"):
+            try:
+                yield f, json.loads(f.read_text(encoding="utf-8")), "pack"
+            except json.JSONDecodeError:
+                continue
+    for f in PLUGINS_DIR.glob("*/plugin.json"):
+        try:
+            yield f, json.loads(f.read_text(encoding="utf-8")), "plugin"
+        except json.JSONDecodeError:
+            continue
+    if HAVE_YAML:
+        for skill_dir in [SKILLS_DIR / "Standard", SKILLS_DIR / "User"]:
+            if not skill_dir.exists():
+                continue
+            for f in skill_dir.glob("*.yaml"):
+                try:
+                    data = yaml.safe_load(f.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        yield f, data, "skill"
+                except yaml.YAMLError:
+                    continue
+
+
+def check_compat(core_version: str | None) -> list[str]:
+    """Enforce compat.min_core_version semantics across all relevant assets.
+
+    - Every layout / pack / plugin / skill must declare ``compat.min_core_version``
+      as a valid semver string. (Existing files added before this ticket are
+      grandfathered via ``--allow-missing-compat``; default is strict.)
+    - When ``core_version`` is provided, refuse any asset whose
+      ``min_core_version`` is newer than the running core.
+    """
+    errors: list[str] = []
+    for path, data, kind in _walk_compat_objects():
+        compat = data.get("compat")
+        if not isinstance(compat, dict):
+            errors.append(
+                f"{path}: missing 'compat' object (expected compat.min_core_version for {kind})"
+            )
+            continue
+        min_core = compat.get("min_core_version")
+        if not min_core:
+            errors.append(f"{path}: compat.min_core_version missing")
+            continue
+        if not SEMVER_RE.match(str(min_core)):
+            errors.append(
+                f"{path}: compat.min_core_version={min_core!r} is not a valid semver string"
+            )
+            continue
+        if core_version is not None:
+            try:
+                running = _parse_semver(core_version)
+            except ValueError:
+                errors.append(
+                    f"--core-version={core_version!r} is not a valid semver string"
+                )
+                return errors
+            if not _semver_le(str(min_core), core_version):
+                errors.append(
+                    f"{path}: requires core >={min_core} but running core is "
+                    f"{running[0]}.{running[1]}.{running[2]}"
+                )
+        max_core = compat.get("max_core_version")
+        if max_core and not SEMVER_RE.match(str(max_core)):
+            errors.append(
+                f"{path}: compat.max_core_version={max_core!r} is not a valid semver string"
+            )
+    return errors
+
+
+# ----- Entry point ---------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate StudioBrain template assets.")
+    parser.add_argument(
+        "--core-version",
+        help="Running core version (semver). When set, assets whose min_core_version "
+             "is newer than this are rejected.",
+    )
+    parser.add_argument(
+        "--allow-missing-compat",
+        action="store_true",
+        help="Do not require assets to declare compat.min_core_version. Useful while "
+             "migrating existing content; default is strict.",
+    )
+    parser.add_argument(
+        "--no-entity-yaml",
+        action="store_true",
+        help="Skip entity markdown frontmatter validation (faster local pass).",
+    )
+    parser.add_argument(
+        "--no-compat",
+        action="store_true",
+        help="Skip compat (min_core_version) enforcement entirely.",
+    )
+    args = parser.parse_args(argv)
+
+    if not HAVE_JSONSCHEMA:
+        _info("WARNING: jsonschema not installed — schema-shape checks will be skipped.")
+    if not HAVE_YAML:
+        _info("WARNING: pyyaml not installed — YAML-dependent checks will be skipped.")
+
+    all_errors: list[str] = []
+
+    _info("== Checking schemas themselves ==")
+    all_errors.extend(check_schemas_are_valid())
+
+    _info("== Validating layouts ==")
+    all_errors.extend(check_layouts())
+
+    _info("== Validating packs ==")
+    all_errors.extend(check_packs())
+
+    _info("== Validating plugins ==")
+    all_errors.extend(check_plugins())
+
+    _info("== Validating skills ==")
+    all_errors.extend(check_skills())
+
+    if not args.no_entity_yaml:
+        _info("== Validating entity markdown frontmatter ==")
+        all_errors.extend(check_entity_frontmatter())
+
+    if not args.no_compat:
+        _info("== Enforcing compat metadata ==")
+        compat_errors = check_compat(args.core_version)
+        if args.allow_missing_compat:
+            compat_errors = [
+                e for e in compat_errors
+                if "missing 'compat' object" not in e
+                and "compat.min_core_version missing" not in e
+            ]
+        all_errors.extend(compat_errors)
+
+    if all_errors:
+        _info("")
+        for e in all_errors:
+            _err(e)
+        _info(f"\nFAILED: {len(all_errors)} error(s).")
+        return 1
+
+    _info("\nOK: all validations passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/studiobrain_templates/__init__.py
+++ b/studiobrain_templates/__init__.py
@@ -1,7 +1,7 @@
 """StudioBrain Templates — pip-installable data package.
 
 Provides filesystem paths to bundled templates, rules, plugins, schemas,
-and layouts so that the StudioBrain backend can discover them at runtime.
+skills, and layouts so that the StudioBrain backend can discover them at runtime.
 
 All content types live under templates/ with subdirectories:
   Standard/           — core entity templates
@@ -34,6 +34,27 @@ PLUGINS_DIR: Path = _PKG_ROOT / "plugins"
 """Path to the ``plugins/`` tree."""
 
 SCHEMAS_DIR: Path = _PKG_ROOT / "schemas"
-"""Path to the ``schemas/`` tree (JSON Schema for entity frontmatter validation)."""
+"""Path to the ``schemas/`` tree (JSON Schema for entity frontmatter validation,
+layout/pack/plugin/skill contracts, and compat metadata)."""
 
-__all__ = ["TEMPLATES_DIR", "RULES_DIR", "PLUGINS_DIR", "SCHEMAS_DIR"]
+SKILLS_DIR: Path = _PKG_ROOT / "skills"
+"""Path to the ``skills/`` tree (AI skill YAML definitions with frontmatter
+validated against schemas/skill.yaml.json)."""
+
+LAYOUTS_DIR: Path = TEMPLATES_DIR / "Layouts"
+"""Path to the ``templates/Layouts/`` tree (UI layout JSON, validated against
+schemas/layout.json)."""
+
+PACKS_DIR: Path = TEMPLATES_DIR / "Packs"
+"""Path to the ``templates/Packs/`` tree (template pack manifests, validated
+against schemas/pack.json)."""
+
+__all__ = [
+    "TEMPLATES_DIR",
+    "RULES_DIR",
+    "PLUGINS_DIR",
+    "SCHEMAS_DIR",
+    "SKILLS_DIR",
+    "LAYOUTS_DIR",
+    "PACKS_DIR",
+]

--- a/templates/Layouts/job.layout.json
+++ b/templates/Layouts/job.layout.json
@@ -224,3 +224,9 @@
       "viewer_component": null
     }
   ],
+  "updated_at": null,
+  "created_at": null,
+  "view_config": {
+    "layout_driven": true
+  }
+}


### PR DESCRIPTION
Resolves SBAI-4637

## Summary

Publishes JSON Schema contracts for every StudioBrain asset type that lacked one, plus a shared compat metadata definition (`min_core_version` semver) and a central validator that enforces it.

- Five new JSON Schema (Draft 2020-12) files in `schemas/`: `_compat.json`, `layout.json`, `pack.json`, `plugin.json`, `skill.yaml.json`
- New `scripts/validate.py` — single entry point for all CI-facing checks; supports `--core-version` for install-time semver enforcement
- Packaging rot fixes: `MANIFEST.in` includes `skills/` + `scripts/*.py`; `package.json` ships `schemas/`, `skills/`, validator; license corrected `UNLICENSED` → `Apache-2.0`; Python package exports `SKILLS_DIR`, `LAYOUTS_DIR`, `PACKS_DIR`
- CI now calls `scripts/validate.py` instead of inline Python
- JS/TS entry: `index.js` + `index.d.ts` expose directory paths and `loadSchema(name)` helper for downstream SDK consumption

## Files Changed

### New
- `schemas/_compat.json` — shared compat metadata (min_core_version, max_core_version, target_api_version, tested_core_versions)
- `schemas/layout.json` — UI layout contract
- `schemas/pack.json` — template pack contract (id, version, entity_types, is_meta_pack + meta-pack guard)
- `schemas/plugin.json` — plugin manifest contract with three variants via `if/then`: `full`, `frontend-only`, `protocol-adapter`
- `schemas/skill.yaml.json` — AI skill YAML frontmatter contract (skill_id, category, applies_to, capabilities, min_tier, inputs, prompts)
- `scripts/validate.py` — central validator (5+ stages, opt-in strict + semver modes)
- `index.js` — CommonJS entry exposing directory paths + `SCHEMA_FILES` map + `loadSchema(name)` helper
- `index.d.ts` — TypeScript declarations

### Modified
- `MANIFEST.in` — added `skills/`, `scripts/*.py`, README, LICENSE
- `pyproject.toml` — version 0.2.0 → 0.3.0; added `[project.optional-dependencies] validate = [jsonschema, pyyaml]`
- `package.json` — version 0.1.0 → 0.2.0; license `UNLICENSED` → `Apache-2.0` (matches repo LICENSE); added `schemas/`, `skills/`, `scripts/validate.py` to `files`; added `validate:strict` and `validate:core` npm scripts
- `studiobrain_templates/__init__.py` — exported `SKILLS_DIR`, `LAYOUTS_DIR`, `PACKS_DIR`
- `.github/workflows/ci.yml` — replaced inline validate-schemas job with `scripts/validate.py` invocation (uses `--allow-missing-compat` during migration; tracked in SBAI-4649)
- `schemas/README.md` — extended to document every schema, the compat object, plugin variants, settings types, and "how to add a new schema"
- `templates/Layouts/job.layout.json` — fixed truncated JSON (missing root closing brace + `view_config` + timestamps); see SBAI-4650
- `plugins/ltx2-pipeline-wasm/plugin.json` — first worked example of the new `compat` contract

## How to Verify

```bash
# Default CI mode (allows grandfathered assets without compat)
python3 scripts/validate.py --allow-missing-compat

# Strict mode (shows 82 errors — the SBAI-4649 backlog)
python3 scripts/validate.py

# Install-time semver enforcement
python3 scripts/validate.py --core-version 0.3.0
python3 scripts/validate.py --core-version 0.2.0  # fails: ltx2-pipeline-wasm requires >=0.3.0

# Confirm Python package exports the new paths
python3 -c "from studiobrain_templates import SKILLS_DIR, LAYOUTS_DIR, PACKS_DIR; print(SKILLS_DIR.exists(), LAYOUTS_DIR.exists(), PACKS_DIR.exists())"

# Confirm JS bridge loads schemas
node -e "console.log(Object.keys(require('./index.js')).length, 'exports; layout title:', require('./index.js').loadSchema('layout').title)"
```

## Decisions & Tradeoffs

- **Three plugin variants** in the schema enum (`full`, `frontend-only`, `protocol-adapter`) instead of two — discovered `data-notes` plugin uses `frontend-only` mid-implementation.
- **Layout `version` field accepts both `1.0` (X.Y) and `1.0.0` (X.Y.Z)** — existing layouts all use X.Y, so breaking them was not worth the purity.
- **Layout field `key` accepts dotted paths** like `color_palette.primary` — location.layout.json uses them for nested fields.
- **Plugin settings `type` enum includes `secret` and `object`** — both patterns are in active use across the existing 22 plugins (14 plugins use `secret` for API keys; import-export-pipeline-wasm uses `object` for nested config).
- **Plugin panel `location` is not required** — some plugins use `type` as an alias field. Both are accepted.
- **CI uses `--allow-missing-compat` during migration** — strict mode would block the build today because 82 existing assets don't declare `compat.min_core_version` yet. SBAI-4649 tracks the backfill.

## Out of Scope

- **Cross-repo SDK consumption in `@biloxistudios/studiobrain-sdk`** (lives in studiobrain-core): the schemas are now reachable via `index.js`, but wiring the TypeScript SDK to import them is a separate ticket. Manager reroute needed if desired before this is closed.
- **Bulk backfill of `compat.min_core_version`** across 82 existing assets — filed as SBAI-4649.

## Filed Follow-ups

- SBAI-4649 — Backfill compat.min_core_version across 82 existing layouts/packs/plugins/skills
- SBAI-4650 — Traceability note for the job.layout.json truncation fix

Generated with [Claude Code](https://claude.com/claude-code)
