### PR TITLE
SBAI-4650: Restore truncated job.layout.json root-level fields

### DIFF
--- a/templates/Layouts/job.layout.json
+++ b/templates/Layouts/job.layout.json
@@ -224,3 +224,9 @@
       "viewer_component": null
     }
   ],
+  "updated_at": null,
+  "created_at": null,
+  "view_config": {
+    "layout_driven": true
+  }
+}


### PR DESCRIPTION
Resolves SBAI-4650

## Summary
The templates/Layouts/job.layout.json file was truncated after the sections array, missing the root-level closing keys (updated_at, created_at, view_config) and the final closing brace. This made the file invalid JSON.

## Files Changed
- templates/Layouts/job.layout.json - Added missing updated_at, created_at, view_config, and closing brace.

## Testing
- Verified JSON parses successfully with python3 -m json.tool
- Confirmed all 6 root-level keys present
- File has 6 sections intact, no data loss

## Notes
- This was originally discovered and fixed inline during SBAI-4637. This PR applies the same fix independently for traceability.