### PR TITLE
SBAI-5579: add location and primary_locations to campaign schema

### DIFF
--- a/schemas/campaign.json
+++ b/schemas/campaign.json
@@ -63,6 +63,27 @@
         "type": "string"
       }
     },
+    "location": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "primary_locations": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "starting_location": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "key_locations": {
       "type": [
         "array",


### PR DESCRIPTION
Resolves SBAI-5579 by adding missing location fields to campaign schema.