### PR TITLE
SBAI-6815: mark the legacy Python plugin catalog deprecated, point authors at the WASM Component SDK

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,6 +1,39 @@
 # _Plugins Directory
 
-This directory contains all StudioBrain plugins. Each plugin is a subdirectory with a `plugin.json` manifest.
+> ## ⚠️ DEPRECATED — DO NOT BUILD NEW PLUGINS AGAINST THIS DIRECTORY
+>
+> **The 28 plugins in this directory target a plugin host that no longer exists.**
+>
+> Their backends are Python/FastAPI modules (`backend/routes.py`, `backend/events.py`),
+> written for the legacy Python backend that has been retired. The current StudioBrain
+> plugin runtime (`sb-plugin-wasmtime`) loads **WASM Components only** — it cannot load
+> a Python module, so nothing in this directory is loadable today.
+>
+> These plugins were conceptual proof-of-concept designs demonstrating that the plugin
+> *system* could work. They were never production-validated, and no ingestion path ever
+> published them to a user-facing plugin catalog.
+>
+> **Owner decision (2026-08-12, recorded in SBAI-6818):** these are *not* being migrated.
+> The host-interaction model changed completely, so every migration would be a full
+> rewrite with nothing gained by starting from the old source. New, well-designed
+> plugins are being built from scratch on the real SDK instead.
+>
+> ### Build against this instead
+>
+> | What | Where |
+> |---|---|
+> | Guest SDK + WIT world | `studiobrain-core` → `packages/plugin-sdk/wit/` (`plugin.wit`, `world.wit`) |
+> | Starter templates | `studiobrain-core` → `packages/plugin-sdk/templates/` (`rust`, `python`, `typescript`, `frontend-panel`) |
+> | Working reference (Rust) | `studiobrain-core` → `_Plugins/entity-notes`, `_Plugins/entity-snapshots` |
+>
+> Rust plugins use `wit-bindgen`; Python plugins use `componentize-py`. Both emit the
+> WASM **Component** binary format. Plugins built with the **Extism** PDK are also not
+> loadable — Extism produces core wasm modules, which is a different, incompatible ABI.
+>
+> Kept in place for historical reference and for the non-plugin content in this repo
+> (`templates/`, `rules/`, `skills/`), which is unaffected and still current.
+>
+> Tracking: SBAI-6815 · Replacement work: SBAI-6818 · Architecture: SBAI-6854
 
 ## What Plugins Are
 
@@ -10,7 +43,11 @@ Plugins extend StudioBrain with:
 - **Backend API routes** mounted at `/api/ext/{plugin-id}/...`
 - **Entity event handlers** that react to entity lifecycle events
 
-Plugins run in sandboxed iframes (frontend) and are imported as isolated Python modules (backend). They cannot access other tenants' data and cannot write outside their own directory.
+*(Historical — describes the retired Python plugin host, not the current runtime.)*
+Plugins ran in sandboxed iframes (frontend) and were imported as isolated Python modules
+(backend). They could not access other tenants' data and could not write outside their own
+directory. In the current runtime the backend half is a sandboxed WASM Component instead;
+see the deprecation notice above.
 
 ## How to Enable a Plugin
 


### PR DESCRIPTION
## SBAI-6815 — the residual, after the premise was corrected

**Docs only. No manifest changed, no plugin relabelled or removed.**

### Why this is the whole remaining scope

Three findings, established against live state (full evidence on SBAI-6815):

1. **The migration question was already answered by the owner.** SBAI-6818 (Done, merged as
   `studiobrain-core#1637`) records the 2026-08-12 directive: *"don't rewrite unknown-quality legacy
   plugins ... every migration would be a full rewrite anyway ... Instead build a smaller number of
   NEW, well-designed plugins from scratch on the real WASM plugin SDK."* These 28 are not being
   migrated. That is settled.

2. **Nothing is running, so nothing is user-visibly broken.** `kubectl get rollout -n studiobrain`
   shows `accounts`, `accounts-backend`, `frontend` **and `rust-backend` all at 0 replicas** —
   `rust-backend` being `ghcr.io/biloxistudios/studiobrain-cloud-backend`, i.e. current-production
   sb-server itself. `api.studiobrain.ai` returns `503 / no available server` from the Cloudflare
   edge on every plugin route. There is no plugin execution surface of any kind right now.

3. **These were never actually published to users.** `MarketplaceService::upsert_registry_entry` is
   the only writer of `plugin_registry_entries` and has **zero callers** on both `main` and
   `feat/cf-edge-pivot` (positive control: `list_registry` does show callers).
   `POST /api/plugins/marketplace/sync` doesn't sync plugins — it counts template/rule/skill/layout
   rows. `catalog_download.rs` states outright: *"Catalog entry kind. Plugins are excluded."*
   No ingestion path from this repo to a user-facing catalog has ever existed, so there is nothing
   to republish and no installed copies to migrate.

What's left is only that **this repo is public** and `plugins/` still reads as a live catalog. The
one real remaining harm is an outside author building against a dead target. This PR closes exactly
that.

### Also flagged (not fixed here)

`BiloxiStudios/studiobrain-plugins/first-party/` holds 25 `*-wasm` ports of these same plugins that
look like a completed migration. They are **also not loadable**: every one is `extism-pdk = "1"` /
`crate-type = ["cdylib"]`, which is the Extism core-module ABI, while production is wasmtime
**Component Model** (`crates/sb-plugin-wasmtime/Cargo.toml`: *"Plugins are WASM Components ... not
core wasm modules"*). Core has zero Extism dependency, and that repo contains zero built `.wasm`.
The banner warns authors about this too. Disposition of that repo is a separate owner call.

### Verification

`studiobrain-plugins` CI is `disabled_manually` under the SBAI-6942 hold — **I re-enabled nothing.**
This repo's CI *is* active, and I additionally ran all three of its jobs locally against this branch:

| Job | Result |
|---|---|
| `validate-templates` (frontmatter) | PASS |
| `validate-rules` (frontmatter) | PASS |
| `validate-schemas-and-assets` → `scripts/validate.py --allow-missing-compat` | `OK: all validations passed.` |

All 28 `plugin.json` files re-parsed clean; `git diff --stat` is `plugins/README.md` only.

### Why draft

Merging publishes a deprecation notice on a **public** repo — an external-facing product
communication. Per dispatch, anything with external impact is an owner call, so this is staged
ready-to-merge rather than shipped. Content is final; flip to ready and merge on a go.

Ticket: https://biloxistudios.atlassian.net/browse/SBAI-6815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
