### PR TITLE
SBAI-6958: add Cloudflare Worker convention to CLAUDE.md + README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,33 @@ There is no build step. This is a data-only package consumed by the StudioBrain 
 - **Do not modify `_plugins.json` or `_plugin_settings.json` without updating the corresponding plugin directories.**
 - **Template packs** in `templates/Packs/` must include a `pack.json` manifest with metadata.
 - When adding a new entity type, add both the template file (in `templates/Standard/`) and a corresponding rules file (in `rules/`).
+
+
+## Cloudflare Worker Convention (`packages/cloudflare-worker/`)
+
+*Owner-accepted ADR (2026-08-14, group:studiobrain).* Full ADR:
+`/mnt/tank/Studio/Brains/crews/sbcrew/sbcrew-charters/ADR-cloudflare-worker-convention.md`
+
+This repo follows the StudioBrain CF Worker convention:
+
+1. **Canonical path** — CF-specific code lives in `packages/cloudflare-worker/` in this
+   repo's canonical home. The name is deliberately verbose (chosen over `cf`) so no
+   decoder is needed.
+2. **Only CF-specific code goes there** — Worker entrypoint, wrangler config/bindings,
+   DO/R2/D1 glue, container shims. Code that only exists because the target is Workers.
+3. **Portable TS does NOT go there** — Logic moved from Rust that is not CF-specific
+   extends `studiobrain-sdk` (runs everywhere equally). Split axis: content -> templates
+   repo; shared SDK -> core; CF-specific build -> `cloudflare-worker`. Never place by
+   CI convenience.
+4. **Feature-preservation** — Rust-to-TS moves must not lose features. Named risk:
+   serde/Rust JSON-schema enforcement is stronger than zod. Do not move generation
+   shape-enforcement to zod without proven parity (SBAI-5428/5429). If in doubt, it does
+   not move.
+5. **Naming** — Workers named to match their crate/service (e.g. `sb-<domain>-worker`),
+   no opaque names.
+6. **wasm32 boundary guard** — Nothing may be added to a crate in a wasm32 boundary
+   that cannot compile to `wasm32-unknown-unknown`. Use per-target cfg-gating, never a dep
+   that breaks the wasm build (SBAI-6881).
+7. **Deploy preference** — Cloudflare native GitHub-to-Worker git integration. Custom
+   CI deploy workflows are under separate review (SBAI-6935).
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Templates are consumed by StudioBrain's type generation system:
 | [studiobrain-ai](https://github.com/BiloxiStudios/studiobrain-ai) | AI service |
 | [studiobrain-desktop](https://github.com/BiloxiStudios/studiobrain-desktop) | Desktop + mobile apps |
 
+
+## Cloudflare Worker Convention
+
+This repo follows the [StudioBrain CF Worker convention](/mnt/tank/Studio/Brains/crews/sbcrew/sbcrew-charters/ADR-cloudflare-worker-convention.md) (ADR, owner-accepted 2026-08-14):
+
+- CF-specific code lives in `packages/cloudflare-worker/` (Worker entrypoint, wrangler config, DO/R2/D1 glue only)
+- Portable TypeScript logic extends `studiobrain-sdk`, not the worker package
+- Rust-to-TS moves must preserve all features (serde/zod parity required for shape enforcement)
+- Workers named to match their crate/service; wasm32 boundary guard applies
+- Preferred deploy: Cloudflare native GitHub-to-Worker git integration
 ## License
 
 Private. Copyright (c) 2024-2026 Biloxi Studios Inc.


### PR DESCRIPTION
Doc-only: adds the Cloudflare Worker convention block (owner-accepted ADR, 2026-08-14) to this repo's CLAUDE.md and README.

**Full ADR:** `crews/sbcrew/sbcrew-charters/ADR-cloudflare-worker-convention.md`

**What this adds:**
- Convention section in CLAUDE.md (7 decisions: canonical path, CF-only scope, SDK split, feature-preservation, naming, wasm32 guard, deploy preference)
- Condensed convention section in README

**Scope:** doc-only, no code changes.

Refs SBAI-6958.

---

Co-Authored-By: Claude <noreply@anthropic.com>